### PR TITLE
Allow setting custom temp and download paths.

### DIFF
--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -71,6 +71,8 @@ public:
     Settings *tsettings;
 
     QString phoneNumber;
+    QString downloadPath;
+    QString tempPath;
     QString configPath;
     QString publicKeyFile;
 
@@ -244,12 +246,30 @@ void TelegramQml::setPhoneNumber(const QString &phone)
 
 QString TelegramQml::downloadPath() const
 {
-    return p->configPath + "/" + phoneNumber() + "/downloads";
+    return p->downloadPath + "/" + phoneNumber() + "/downloads";
+}
+
+void TelegramQml::setDownloadPath(const QString &downloadPath)
+{
+    if( p->downloadPath == downloadPath )
+        return;
+
+    p->downloadPath = downloadPath;
+    Q_EMIT downloadPathChanged();
 }
 
 QString TelegramQml::tempPath() const
 {
-    return p->configPath + "/" + phoneNumber() + "/temp";
+    return p->tempPath + "/" + phoneNumber() + "/temp";
+}
+
+void TelegramQml::setTempPath(const QString &tempPath)
+{
+    if( p->tempPath == tempPath)
+        return;
+
+    p->tempPath = tempPath;
+    Q_EMIT tempPathChanged();
 }
 
 QString TelegramQml::configPath() const
@@ -265,6 +285,11 @@ void TelegramQml::setConfigPath(const QString &conf)
     p->configPath = conf;
     p->database->setConfigPath(conf);
     p->userdata->setConfigPath(conf);
+
+    if( p->tempPath.isEmpty() )
+        p->tempPath = conf;
+    if( p->downloadPath.isEmpty() )
+        p->downloadPath = conf;
 
     try_init();
 

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -90,8 +90,8 @@ class TELEGRAMQMLSHARED_EXPORT TelegramQml : public QObject
     Q_PROPERTY(QString phoneNumber   READ phoneNumber   WRITE setPhoneNumber   NOTIFY phoneNumberChanged  )
     Q_PROPERTY(QString configPath    READ configPath    WRITE setConfigPath    NOTIFY configPathChanged   )
     Q_PROPERTY(QString publicKeyFile READ publicKeyFile WRITE setPublicKeyFile NOTIFY publicKeyFileChanged)
-    Q_PROPERTY(QString downloadPath  READ downloadPath  NOTIFY downloadPathChanged )
-    Q_PROPERTY(QString tempPath      READ tempPath      NOTIFY tempPathChanged     )
+    Q_PROPERTY(QString downloadPath  READ downloadPath  WRITE setDownloadPath  NOTIFY downloadPathChanged )
+    Q_PROPERTY(QString tempPath      READ tempPath      WRITE setTempPath      NOTIFY tempPathChanged     )
 
     Q_PROPERTY(QObject* newsLetterDialog READ newsLetterDialog WRITE setNewsLetterDialog NOTIFY newsLetterDialogChanged     )
     Q_PROPERTY(bool autoCleanUpMessages READ autoCleanUpMessages WRITE setAutoCleanUpMessages NOTIFY autoCleanUpMessagesChanged)
@@ -138,7 +138,10 @@ public:
     void setPhoneNumber( const QString & phone );
 
     QString downloadPath() const;
+    void setDownloadPath( const QString & downloadPath );
+
     QString tempPath() const;
+    void setTempPath( const QString & tempPath );
 
     QString configPath() const;
     void setConfigPath( const QString & conf );


### PR DESCRIPTION
Due to how TelegramQml::setConfigPath is implemented, this should have no effect on the clients currently using TelegramQML. This change adds the possibility to set tempPath and downloadPath on the Telegram object, so that, for instance, downloads are stored in .cache rather than .config subdirectory.
