### PR TITLE
Add DetailedContactsModel and ContactsFilterModel for easy filtering …

### DIFF
--- a/telegramcontactsfiltermodel.cpp
+++ b/telegramcontactsfiltermodel.cpp
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2015 Canonical
+
+    This project is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This project is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <QRegExp>
+
+#include "telegramdetailedcontactsmodel.h"
+#include "telegramcontactsfiltermodel.h"
+
+TelegramContactsFilterModel::TelegramContactsFilterModel(QObject *parent) :
+        QSortFilterProxyModel(parent), mOwnId(0), mSearchTerm("")
+{
+}
+
+TelegramContactsFilterModel::~TelegramContactsFilterModel()
+{
+}
+
+bool TelegramContactsFilterModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const {
+    QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
+
+    QString fullName = sourceModel()->data(index, TelegramDetailedContactsModel::FullNameRole).toString();
+    qint32 id = sourceModel()->data(index, TelegramDetailedContactsModel::IdRole).toInt();
+
+    bool notSelf = (id != mOwnId);
+    return notSelf && (fullName.contains(filterRegExp()));
+}
+
+QString TelegramContactsFilterModel::searchTerm() const
+{
+    return mSearchTerm;
+}
+
+void TelegramContactsFilterModel::setSearchTerm(const QString &searchTerm)
+{
+    if (mSearchTerm != searchTerm) {
+        mSearchTerm = searchTerm;
+
+        QString pattern = QString("\\b%1").arg(searchTerm);
+        setFilterKeyColumn(0);
+        setFilterRegExp(QRegExp(pattern, Qt::CaseInsensitive));
+
+        Q_EMIT searchTermChanged();
+    }
+}
+
+QVariant TelegramContactsFilterModel::get(int rowIndex) const {
+    QVariantMap data;
+    QModelIndex sourceIndex = mapToSource(index(rowIndex, 0));
+    if (sourceIndex.isValid()) {
+        QAbstractItemModel *source = sourceModel();
+        QHash<int, QByteArray> roles = source->roleNames();
+        Q_FOREACH(int role, roles.keys()) {
+            data.insert(roles[role], source->data(sourceIndex, role));
+        }
+    }
+    return data;
+}
+

--- a/telegramcontactsfiltermodel.h
+++ b/telegramcontactsfiltermodel.h
@@ -1,0 +1,53 @@
+/*
+    Copyright (C) 2015 Canonical
+
+    This project is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This project is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef TELEGRAMCONTACTSFILTERMODEL_H
+#define TELEGRAMCONTACTSFILTERMODEL_H
+
+#include <QSortFilterProxyModel>
+
+#include "telegramqml_global.h"
+
+class TELEGRAMQMLSHARED_EXPORT TelegramContactsFilterModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(int count READ rowCount NOTIFY countChanged)
+    Q_PROPERTY(QString searchTerm READ searchTerm WRITE setSearchTerm NOTIFY searchTermChanged)
+
+public:
+    TelegramContactsFilterModel(QObject *parent = 0);
+    ~TelegramContactsFilterModel();
+
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
+
+    Q_INVOKABLE QVariant get(int rowIndex) const;
+
+    QString searchTerm() const;
+    void setSearchTerm(const QString &searchTerm);
+
+Q_SIGNALS:
+    void searchTermChanged();
+    void countChanged();
+
+private:
+    qint64 mOwnId;
+    QString mSearchTerm;
+};
+
+#endif // TELEGRAMCONTACTSFILTERMODEL_H

--- a/telegramdetailedcontactsmodel.cpp
+++ b/telegramdetailedcontactsmodel.cpp
@@ -1,0 +1,197 @@
+/*
+    Copyright (C) 2014 Aseman, 2015 Canonical
+    http://aseman.co
+
+    This project is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This project is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "telegramdetailedcontactsmodel.h"
+#include "telegramqml.h"
+#include "objects/types.h"
+
+#include <telegram.h>
+
+class TelegramDetailedContactsModelPrivate
+{
+public:
+    TelegramQml *telegram;
+    QList<qint64> contacts;
+    bool initializing;
+};
+
+TelegramDetailedContactsModel::TelegramDetailedContactsModel(QObject *parent) :
+    QAbstractListModel(parent)
+{
+    p = new TelegramDetailedContactsModelPrivate;
+    p->telegram = 0;
+    p->initializing = false;
+}
+
+TelegramQml *TelegramDetailedContactsModel::telegram() const
+{
+    return p->telegram;
+}
+
+void TelegramDetailedContactsModel::setTelegram(TelegramQml *tgo)
+{
+    TelegramQml *tg = static_cast<TelegramQml*>(tgo);
+    if( p->telegram == tg )
+        return;
+
+    p->telegram = tg;
+    Q_EMIT telegramChanged();
+    if( !p->telegram )
+        return;
+
+    connect( p->telegram, SIGNAL(contactsChanged()), SLOT(contactsChanged()) );
+    refresh();
+}
+
+qint64 TelegramDetailedContactsModel::id(const QModelIndex &index) const
+{
+    int row = index.row();
+    return p->contacts.at(row);
+}
+
+int TelegramDetailedContactsModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent)
+    return p->contacts.count();
+}
+
+QVariant TelegramDetailedContactsModel::data(const QModelIndex &index, int role) const
+{
+    QVariant res;
+    const qint64 key = id(index);
+    UserObject* user = p->telegram->user(key);
+
+    switch( role )
+    {
+    case ItemRole:
+        res = QVariant::fromValue<UserObject*>(user);
+        break;
+    case IdRole:
+        res = user->id();
+        break;
+    case AccessHashRole:
+        res = user->accessHash();
+        break;
+    case PhoneRole:
+        res = user->phone();
+        break;
+    case FirstNameRole:
+        res = user->firstName();
+        break;
+    case LastNameRole:
+        res = user->lastName();
+        break;
+    case FullNameRole: {
+        QString full = user->firstName();
+        if (user->lastName().length() > 0) {
+            full.append(" ").append(user->lastName());
+        }
+        res = full;
+        break;
+    }
+    case UsernameRole:
+        res = user->username();
+        break;
+    case PhotoRole:
+        res = QVariant::fromValue<UserProfilePhotoObject*>(user->photo());
+        break;
+    case StatusRole:
+        res = QVariant::fromValue<UserStatusObject*>(user->status());
+        break;
+    }
+
+    return res;
+}
+
+QHash<qint32, QByteArray> TelegramDetailedContactsModel::roleNames() const
+{
+    static QHash<qint32, QByteArray> *res = 0;
+    if( res )
+        return *res;
+
+    res = new QHash<qint32, QByteArray>();
+    res->insert(ItemRole, "user");
+    res->insert(IdRole, "id");
+    res->insert(AccessHashRole, "accessHash");
+    res->insert(PhoneRole, "phoneRole");
+    res->insert(FirstNameRole, "firstName");
+    res->insert(LastNameRole, "lastName");
+    res->insert(FullNameRole, "fullName");
+    res->insert(UsernameRole, "username");
+    res->insert(PhotoRole, "photo");
+    res->insert(StatusRole, "status");
+    return *res;
+}
+
+int TelegramDetailedContactsModel::count() const
+{
+    return p->contacts.count();
+}
+
+bool TelegramDetailedContactsModel::initializing() const
+{
+    return p->initializing;
+}
+
+void TelegramDetailedContactsModel::refresh()
+{
+    if( !p->telegram )
+        return;
+
+    contactsChanged();
+    p->telegram->telegram()->contactsGetContacts();
+
+    p->initializing = true;
+    Q_EMIT initializingChanged();
+}
+
+void TelegramDetailedContactsModel::contactsChanged()
+{
+    const QList<qint64> & contacts_unsort = p->telegram->contacts();
+    QMap<QString,qint64> sort_map;
+    Q_FOREACH( qint64 id, contacts_unsort )
+    {
+        UserObject *user = p->telegram->user(id);
+        sort_map.insertMulti( user->firstName() + " " + user->lastName(), id );
+    }
+
+    const QList<qint64> & contacts = sort_map.values();
+
+    beginResetModel();
+    p->contacts.clear();
+    endResetModel();
+
+    for( int i=0 ; i<contacts.count() ; i++ )
+    {
+        const qint64 dId = contacts.at(i);
+        if( p->contacts.contains(dId) )
+            continue;
+
+        beginInsertRows(QModelIndex(), i, i );
+        p->contacts.insert( i, dId );
+        endInsertRows();
+    }
+
+    p->initializing = false;
+    Q_EMIT initializingChanged();
+}
+
+TelegramDetailedContactsModel::~TelegramDetailedContactsModel()
+{
+    delete p;
+}

--- a/telegramdetailedcontactsmodel.h
+++ b/telegramdetailedcontactsmodel.h
@@ -1,0 +1,81 @@
+/*
+    Copyright (C) 2014 Aseman, 2015 Canonical
+    http://aseman.co
+
+    This project is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This project is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TELEGRAMDETAILEDCONTACTSMODEL_H
+#define TELEGRAMDETAILEDCONTACTSMODEL_H
+
+#include <QAbstractListModel>
+
+#include "telegramqml_global.h"
+
+class TelegramQml;
+class TelegramDetailedContactsModelPrivate;
+class TELEGRAMQMLSHARED_EXPORT TelegramDetailedContactsModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+    Q_PROPERTY(TelegramQml* telegram READ telegram WRITE setTelegram NOTIFY telegramChanged)
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(bool initializing READ initializing NOTIFY initializingChanged)
+
+public:
+    enum DialogsRoles {
+        ItemRole = Qt::UserRole,
+        IdRole,
+        AccessHashRole,
+        PhoneRole,
+        FirstNameRole,
+        LastNameRole,
+        FullNameRole,
+        UsernameRole,
+        PhotoRole,
+        StatusRole
+    };
+
+    TelegramDetailedContactsModel(QObject *parent = 0);
+    ~TelegramDetailedContactsModel();
+
+    TelegramQml *telegram() const;
+    void setTelegram(TelegramQml *tg );
+
+    qint64 id( const QModelIndex &index ) const;
+    int rowCount(const QModelIndex & parent = QModelIndex()) const;
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+
+    QHash<qint32,QByteArray> roleNames() const;
+
+    int count() const;
+    bool initializing() const;
+
+public Q_SLOTS:
+    void refresh();
+
+Q_SIGNALS:
+    void telegramChanged();
+    void countChanged();
+    void initializingChanged();
+
+private Q_SLOTS:
+    void contactsChanged();
+
+private:
+    TelegramDetailedContactsModelPrivate *p;
+};
+
+#endif // TELEGRAMDETAILEDCONTACTSMODEL_H

--- a/telegramqml.pri
+++ b/telegramqml.pri
@@ -40,6 +40,8 @@ SOURCES += \
     $$PWD/tagfiltermodel.cpp \
     $$PWD/telegramchatparticipantsmodel.cpp \
     $$PWD/telegramcontactsmodel.cpp \
+    $$PWD/telegramdetailedcontactsmodel.cpp \
+    $$PWD/telegramcontactsfiltermodel.cpp \
     $$PWD/telegramdialogsmodel.cpp \
     $$PWD/telegramfilehandler.cpp \
     $$PWD/telegrammessagesmodel.cpp \
@@ -66,6 +68,8 @@ HEADERS += \
     $$PWD/tagfiltermodel.h \
     $$PWD/telegramchatparticipantsmodel.h \
     $$PWD/telegramcontactsmodel.h \
+    $$PWD/telegramdetailedcontactsmodel.h \
+    $$PWD/telegramcontactsfiltermodel.h \
     $$PWD/telegramdialogsmodel.h \
     $$PWD/telegramfilehandler.h \
     $$PWD/telegrammessagesmodel.h \

--- a/telegramqml.pro
+++ b/telegramqml.pro
@@ -60,6 +60,8 @@ SOURCES += \
     tagfiltermodel.cpp \
     telegramchatparticipantsmodel.cpp \
     telegramcontactsmodel.cpp \
+    telegramdetailedcontactsmodel.cpp \
+    telegramcontactsfiltermodel.cpp \
     telegramdialogsmodel.cpp \
     telegramfilehandler.cpp \
     telegrammessagesmodel.cpp \
@@ -87,6 +89,8 @@ HEADERS += \
     tagfiltermodel.h \
     telegramchatparticipantsmodel.h \
     telegramcontactsmodel.h \
+    telegramdetailedcontactsmodel.h \
+    telegramcontactsfiltermodel.h \
     telegramdialogsmodel.h \
     telegramfilehandler.h \
     telegrammessagesmodel.h \

--- a/telegramqmlinitializer.cpp
+++ b/telegramqmlinitializer.cpp
@@ -15,6 +15,8 @@
 #include "tagfiltermodel.h"
 #include "telegramchatparticipantsmodel.h"
 #include "telegramcontactsmodel.h"
+#include "telegramdetailedcontactsmodel.h"
+#include "telegramcontactsfiltermodel.h"
 #include "telegramdialogsmodel.h"
 #include "telegramfilehandler.h"
 #include "telegrammessagesmodel.h"
@@ -45,6 +47,8 @@ void TelegramQmlInitializer::init(const char *uri)
     qmlRegisterType<TagFilterModel>(uri, 1, 0, "TagFilterModel");
     qmlRegisterType<TelegramChatParticipantsModel>(uri, 1, 0, "ChatParticipantsModel");
     qmlRegisterType<TelegramContactsModel>(uri, 1, 0, "ContactsModel");
+    qmlRegisterType<TelegramContactsFilterModel>(uri, 1, 0, "ContactsFilterModel");
+    qmlRegisterType<TelegramDetailedContactsModel>(uri, 1, 0, "DetailedContactsModel");
     qmlRegisterType<TelegramDialogsModel>(uri, 1, 0, "DialogsModel");
     qmlRegisterType<TelegramFileHandler>(uri, 1, 0, "FileHandler");
     qmlRegisterType<TelegramMessagesModel>(uri, 1, 0, "MessagesModel");


### PR DESCRIPTION
DetailedContactsModel exposes a bunch of roles, so that developers can consume attached properties directly in their list delegate, instead of having to request a user object in each delegate. This also allows to utilize things like easier adding of list sections (based on "firstName" property, for instance), as well as makes the ContactsFilterModel easy to implement.

This is a larger pull request. Please feel free to comment, I will be happy to address your feedback (whether it's regarding logic, style, headers, etc).
