### PR TITLE
Thumbnailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,12 @@ To build TelegramQml in the plugin mode run:
 and to build in the library mode run:
 
     qmake -r .. PREFIX=/usr BUILD_MODE+=lib
+
+To make use of thumbnailer on the Ubuntu phone (which does not ship with ffmpeg), add the following to the qmake commands above:
+
+    LIBS+=-lthumbnailer DEFINES+=UBUNTU_PHONE
     
-then start build process:
+Then start build process:
     
     make
     make install

--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -30,10 +30,16 @@
 #include <types/decryptedmessage.h>
 #include <limits>
 
+#ifdef UBUNTU_PHONE
+#include <thumbnailer.h>
+#endif
+
 #include <QPointer>
 #include <QTimerEvent>
 #include <QDebug>
+#include <QFile>
 #include <QHash>
+#include <QImage>
 #include <QDateTime>
 #include <QMimeDatabase>
 #include <QMimeType>
@@ -1039,6 +1045,7 @@ QString TelegramQml::localFilesPrePath()
 #endif
 }
 
+#ifndef UBUNTU_PHONE
 bool TelegramQml::createVideoThumbnail(const QString &video, const QString &output, QString ffmpegPath)
 {
     if(ffmpegPath.isEmpty())
@@ -1079,6 +1086,24 @@ bool TelegramQml::createVideoThumbnail(const QString &video, const QString &outp
 
     return prc.exitCode() == 0;
 }
+#else
+bool TelegramQml::createVideoThumbnail(const QString &video, const QString &output, QString ffmpegPath)
+{
+    Q_UNUSED(ffmpegPath);
+
+    Thumbnailer thumbnailer;
+    std::string thumbnail = thumbnailer.get_thumbnail(video.toStdString(), TN_SIZE_SMALL);
+    QString thumbOutput = QString::fromStdString(thumbnail);
+    QImage image;
+    image.load(thumbOutput);
+    image.save(output, "JPEG");
+
+    QFile thumb(thumbOutput);
+    thumb.remove();
+
+    return true;
+}
+#endif
 
 bool TelegramQml::createAudioThumbnail(const QString &audio, const QString &output)
 {


### PR DESCRIPTION
Add support for thumbnailer on Ubuntu Phone. Introduces no API changes for current clients. Because the thumbnailer (in its current implementation) stores thumbs in png, they are immediately converted to jpeg's, and original files are removed. This is useful, as Telegram does not accept png thumbs.
