### PR TITLE
More contact features

### DIFF
--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -584,6 +584,7 @@ QString TelegramQml::error() const
 
 void TelegramQml::authCheckPhone(const QString &phone)
 {
+    p->checkphone_req_id = 0;
     qint64 id = p->telegram->authCheckPhone(phone);
     p->phoneCheckIds.insert(id, phone);
 }
@@ -2304,7 +2305,7 @@ void TelegramQml::authLoggedIn_slt()
 
     Q_EMIT authNeededChanged();
     Q_EMIT authLoggedInChanged();
-    Q_EMIT authPhoneChecked();
+    Q_EMIT authPhoneCheckedChanged();
     Q_EMIT meChanged();
 
     QTimer::singleShot(1000, this, SLOT(updatesGetState()));
@@ -2373,7 +2374,7 @@ void TelegramQml::authCheckPhone_slt(qint64 id, bool phoneRegistered)
             p->telegram->authSendCode();
     } else {
         p->phoneCheckIds.remove(id);
-        Q_EMIT authPhoneChecked(phone, phoneRegistered);
+        Q_EMIT phoneChecked(phone, phoneRegistered);
     }
 }
 

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -341,7 +341,7 @@ Q_SIGNALS:
     void authPhoneRegisteredChanged();
     void authPhoneInvitedChanged();
     void authPhoneCheckedChanged();
-    void authPhoneChecked(const QString &phone, bool phoneRegistered);
+    void phoneChecked(QString phone, bool phoneRegistered);
     void authPasswordProtectedError();
     void connectedChanged();
 

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -206,6 +206,8 @@ public:
 
     Q_INVOKABLE void authCheckPhone(const QString &phone);
 
+    Q_INVOKABLE void helpGetInviteText(const QString &langCode);
+
     Q_INVOKABLE DialogObject *dialog(qint64 id) const;
     Q_INVOKABLE MessageObject *message(qint64 id) const;
     Q_INVOKABLE ChatObject *chat(qint64 id) const;
@@ -267,6 +269,7 @@ public Q_SLOTS:
     void sendGeo(qint64 dialogId, qreal latitude, qreal longitude, int replyTo = 0);
 
     void addContact(const QString &firstName, const QString &lastName, const QString &phoneNumber);
+    void addContacts(const QVariantList &vcontacts);
 
     void forwardMessages( QList<int> msgIds, qint64 peerId );
     void deleteMessages(QList<int> msgIds );
@@ -355,6 +358,10 @@ Q_SIGNALS:
     void userBecomeOnline(qint64 userId);
     void userStartTyping(qint64 userId, qint64 dId);
 
+    void contactsImportedContacts(qint32 importedCount, qint32 retryCount);
+
+    void helpGetInviteTextAnswer(qint64 id, QString message);
+
     void errorChanged();
     void meChanged();
     void fakeSignal();
@@ -364,6 +371,8 @@ Q_SIGNALS:
 
     void searchDone(const QList<qint64> &messages);
     void contactsFounded(const QList<qint32> &contacts);
+
+    void errorSignal(qint64 id, qint32 errorCode, QString functionName, QString errorText);
 
 protected:
     void try_init();
@@ -379,7 +388,7 @@ private Q_SLOTS:
     void authCheckPhone_slt(qint64 id, bool phoneRegistered);
     void authSignInError_slt(qint64 id, qint32 errorCode, QString errorText);
     void authSignUpError_slt(qint64 id, qint32 errorCode, QString errorText);
-    void error(qint64 id, qint32 errorCode, QString functionName, QString errorText);
+    void error_slt(qint64 id, qint32 errorCode, QString errorText, QString functionName);
 
     void accountGetPassword_slt(qint64 msgId, const AccountPassword &password);
     void accountGetWallPapers_slt(qint64 id, const QList<WallPaper> & wallPapers);


### PR DESCRIPTION
Sorry I did not break up the commits, I'm running short on time. Allow me for detailed explanation:
- clearing checkphone_req_id when checking not-own phone number ensures proper code path on response (processing own phone check VS emitting phoneChecked signal)
- added fetching invite text (so one can send with SMS, for instance, to invite to Telegram)
- adding contacts in batch -- I decided not to use custom types here, so that this can be used from QML/JS as follows:
  
  ```
  var contactList = [];
  for (var i = 0; i < contacts.length; i++) {
      var contact = parseContact(contacts[i]);
      // parseContact simply returns JS object, {"phone": "..", "firstName": "..", "lastName": ".."}
      if (contact.phone !== "" && contact.firstName !== "") {
          contactList.push(contact);
      }
  }
  // connect to contactsImportedContacts, and then
  telegram.addContacts(contactList, false);
  ```
- renamed error slot to error_slt to make it more consistent and make room for..
- error signal! no wait, there's a property named like that :/ so you can't connect to it from JS, so...
- errorSignal surfaces the error to the UI via signal. I really had no better name for it, ugh. It's unfortunate there's "error" property, hence with that we have "onErrorSignal" instead of simple "onError" in QML. On that note, you may say "why not use onErrorChanged from Telegram object" - this works, but developers may want to track errors from elsewhere, and connecting to signal is, in my opinion, sometimes cleaner than using Connections. Not sure. I think we should we give developers the freedom to chose? Compare (main difference is the signal contains id, code and text, whereas the second solution just text):

```
Page {
    signal error(...)
    onError: {  }

    [...] telegram.errorSignal.connect(error); [...]
}

Page {
    Connections {
        target: telegram // telegramObject
        onErrorChanged: {  }
    }
}
```
- authPhoneChecked changes wrap the previous change. seems a refactor affected one line incorrectly, and the other is a call to phoneChecked(phone, phoneRegistered) signal, that is emitted for other than own-phone number checks.

This time I struggled with name clashes. Now I realize I named helpGetInviteTextAnswer inconsistently with errorSignal. But I think you understand how it hurts me using "Signal" in a signal name ;D And errorAnswer makes no sense. Help me out, maybe we can come up with consistent naming guidelines.

I also noticed there's some style inconsistencies in code, such as:

```
if ( foo )
if (foo)
if ( foo->bar)
```

Perhaps when we have time we can address those and other similar. Not here though, this already touched too many places.
