### PR TITLE
Add property to allow auto accepting encrypted chats.

### DIFF
--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -87,6 +87,7 @@ public:
     int unreadCount;
     qreal totalUploadedPercent;
 
+    bool autoAcceptEncrypted;
     bool autoCleanUpMessages;
 
     bool authNeeded;
@@ -182,6 +183,7 @@ TelegramQml::TelegramQml(QObject *parent) :
     p->msg_send_id_counter = INT_MAX - 100000;
     p->msg_send_random_id = 0;
     p->newsletter_dlg = 0;
+    p->autoAcceptEncrypted = false;
     p->autoCleanUpMessages = false;
 
     p->cleanUpTimer = new QTimer(this);
@@ -423,6 +425,21 @@ void TelegramQml::setNewsLetterDialog(QObject *dialog)
 QObject *TelegramQml::newsLetterDialog() const
 {
     return p->newsletter_dlg;
+}
+
+void TelegramQml::setAutoAcceptEncrypted(bool stt)
+{
+    if(p->autoAcceptEncrypted == stt)
+        return;
+
+    p->autoAcceptEncrypted = stt;
+
+    Q_EMIT autoAcceptEncryptedChanged();
+}
+
+bool TelegramQml::autoAcceptEncrypted() const
+{
+    return p->autoAcceptEncrypted;
 }
 
 void TelegramQml::setAutoCleanUpMessages(bool stt)
@@ -3014,6 +3031,10 @@ void TelegramQml::messagesEncryptedChatRequested_slt(qint32 chatId, qint32 date,
     }
 
     insertEncryptedChat(c);
+
+    if (p->autoAcceptEncrypted) {
+        p->telegram->messagesAcceptEncryptedChat(chatId);
+    }
 }
 
 void TelegramQml::messagesEncryptedChatCreated_slt(qint32 chatId)

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -94,6 +94,7 @@ class TELEGRAMQMLSHARED_EXPORT TelegramQml : public QObject
     Q_PROPERTY(QString tempPath      READ tempPath      WRITE setTempPath      NOTIFY tempPathChanged     )
 
     Q_PROPERTY(QObject* newsLetterDialog READ newsLetterDialog WRITE setNewsLetterDialog NOTIFY newsLetterDialogChanged     )
+    Q_PROPERTY(bool autoAcceptEncrypted READ autoAcceptEncrypted WRITE setAutoAcceptEncrypted NOTIFY autoAcceptEncryptedChanged)
     Q_PROPERTY(bool autoCleanUpMessages READ autoCleanUpMessages WRITE setAutoCleanUpMessages NOTIFY autoCleanUpMessagesChanged)
 
     Q_PROPERTY(bool  online               READ online WRITE setOnline NOTIFY onlineChanged)
@@ -166,6 +167,9 @@ public:
 
     void setNewsLetterDialog(QObject *dialog);
     QObject *newsLetterDialog() const;
+
+    void setAutoAcceptEncrypted(bool stt);
+    bool autoAcceptEncrypted() const;
 
     void setAutoCleanUpMessages(bool stt);
     bool autoCleanUpMessages() const;
@@ -319,6 +323,7 @@ Q_SIGNALS:
     void configPathChanged();
     void publicKeyFileChanged();
     void telegramChanged();
+    void autoAcceptEncryptedChanged();
     void autoCleanUpMessagesChanged();
     void userDataChanged();
     void onlineChanged();


### PR DESCRIPTION
Bardia, can you please help identify the place where to also call
-    if (p->autoAcceptEncrypted) {
-        p->telegram->messagesAcceptEncryptedChat(chatId);
-    }
  so that the app can auto accept when it receives a secret chat dialog after just starting the app? (Secret chat was requested before the app was started.)
