### PR TITLE
Actual muting

### DIFF
--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -612,6 +612,45 @@ void TelegramQml::authCheckPhone(const QString &phone)
     p->phoneCheckIds.insert(id, phone);
 }
 
+void TelegramQml::mute(qint64 peerId) {
+    if(p->userdata) {
+        p->userdata->addMute(peerId);
+    }
+    qint32 muteUntil = QDateTime::currentDateTime().addYears(1).toTime_t();
+    accountUpdateNotifySettings(peerId, muteUntil);
+}
+
+void TelegramQml::unmute(qint64 peerId) {
+    if(p->userdata) {
+        p->userdata->removeMute(peerId);
+    }
+    accountUpdateNotifySettings(peerId, 0);
+}
+
+void TelegramQml::accountUpdateNotifySettings(qint64 peerId, qint32 muteUntil) {
+    bool isChat = p->chats.contains(peerId);
+    InputPeer peer(getInputPeerType(peerId));
+    if(isChat)
+        peer.setChatId(peerId);
+    else
+        peer.setUserId(peerId);
+
+    if(peer.classType() == InputPeer::typeInputPeerForeign)
+    {
+        UserObject *user = p->users.value(peerId);
+        if(user)
+            peer.setAccessHash(user->accessHash());
+    }
+
+    InputNotifyPeer inputNotifyPeer(InputNotifyPeer::typeInputNotifyPeer);
+    inputNotifyPeer.setPeer(peer);
+
+    InputPeerNotifySettings settings;
+    settings.setMuteUntil(muteUntil);
+
+    p->telegram->accountUpdateNotifySettings(inputNotifyPeer, settings);
+}
+
 void TelegramQml::helpGetInviteText(const QString &langCode)
 {
     p->telegram->helpGetInviteText(langCode);
@@ -3598,6 +3637,25 @@ void TelegramQml::insertUpdate(const Update &update)
         break;
 
     case Update::typeUpdateNotifySettings:
+    {
+        NotifyPeer notifyPeer = update.notifyPeer();
+        PeerNotifySettings settings = update.notifySettings();
+        qint32 muteUntil = settings.muteUntil();
+
+        qint32 now = QDateTime::currentDateTime().toTime_t();
+        bool isMuted = (muteUntil > now);
+
+        if (notifyPeer.classType() == NotifyPeer::typeNotifyPeer) {
+            Peer peer = notifyPeer.peer();
+            qint64 peerId = peer.userId() ? peer.userId() : peer.chatId();
+
+            if (isMuted) {
+                p->userdata->addMute(peerId);
+            } else {
+                p->userdata->removeMute(peerId);
+            }
+        }
+    }
         break;
 
     case Update::typeUpdateMessageID:

--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -612,6 +612,19 @@ void TelegramQml::authCheckPhone(const QString &phone)
     p->phoneCheckIds.insert(id, phone);
 }
 
+// WARNING: Push notifications supported for one account only!
+void TelegramQml::accountRegisterDevice(const QString &token, const QString &appVersion) {
+    QString oldToken = p->userdata->pushToken();
+    if (oldToken != token) {
+        p->telegram->accountUnregisterDevice(oldToken);
+    }
+    p->telegram->accountRegisterDevice(token, appVersion);
+}
+
+void TelegramQml::accountUnregisterDevice(const QString &token) {
+    p->telegram->accountUnregisterDevice(token);
+}
+
 void TelegramQml::mute(qint64 peerId) {
     if(p->userdata) {
         p->userdata->addMute(peerId);
@@ -1313,6 +1326,11 @@ void TelegramQml::authLogout()
         return;
     if( p->logout_req_id )
         return;
+
+    QString token = p->userdata->pushToken();
+    if (!token.isEmpty()) {
+        p->telegram->accountUnregisterDevice(token);
+    }
 
     p->logout_req_id = p->telegram->authLogOut();
 }

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -210,6 +210,10 @@ public:
 
     Q_INVOKABLE void authCheckPhone(const QString &phone);
 
+    Q_INVOKABLE void mute(qint64 peerId);
+    Q_INVOKABLE void unmute(qint64 peerId);
+    void accountUpdateNotifySettings(qint64 peerId, qint32 muteUntil);
+
     Q_INVOKABLE void helpGetInviteText(const QString &langCode);
 
     Q_INVOKABLE DialogObject *dialog(qint64 id) const;

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -272,6 +272,9 @@ public Q_SLOTS:
     void authSignIn(const QString &code);
     void authSignUp(const QString &code, const QString &firstName, const QString &lastName);
 
+    void accountRegisterDevice(const QString &token, const QString &appVersion = QString::null);
+    void accountUnregisterDevice(const QString &token);
+
     void sendMessage( qint64 dialogId, const QString & msg, int replyTo = 0 );
     bool sendMessageAsDocument( qint64 dialogId, const QString & msg );
     void sendGeo(qint64 dialogId, qreal latitude, qreal longitude, int replyTo = 0);

--- a/userdata.cpp
+++ b/userdata.cpp
@@ -130,6 +130,19 @@ void UserData::reconnect()
     update_db();
 }
 
+// WARNING: Push notifications supported for one account only!
+void UserData::setPushToken(const QString &token)
+{
+    QString key = QString("push%1").arg(p->phoneNumber);
+    setValue(key, token);
+}
+
+QString UserData::pushToken() const
+{
+    QString key = QString("push%1").arg(p->phoneNumber);
+    return value(key);
+}
+
 void UserData::addMute(int id)
 {
     QSqlQuery mute_query(p->db);
@@ -348,7 +361,7 @@ void UserData::setValue(const QString &key, const QString &value)
     Q_EMIT valueChanged(key);
 }
 
-QString UserData::value(const QString &key)
+QString UserData::value(const QString &key) const
 {
     return p->general.value(key);
 }

--- a/userdata.h
+++ b/userdata.h
@@ -59,6 +59,9 @@ public:
     QString configPath() const;
 
 public Q_SLOTS:
+    void setPushToken(const QString &token);
+    QString pushToken() const;
+
     void addMute( int id );
     void removeMute( int id );
     QList<int> mutes() const;
@@ -86,7 +89,7 @@ public Q_SLOTS:
     MessageUpdate messageUpdateItem(int id);
 
     void setValue( const QString & key, const QString & value );
-    QString value( const QString & key );
+    QString value( const QString & key ) const;
 
     void reconnect();
     void disconnect();


### PR DESCRIPTION
Proxy mute and unmute methods via TelegramQML (instead of directly on userData), so that the setting is actually stored on the server. Surfaced methods to (un)register the device for push notifications.
