### PR TITLE
FileHandler: Check downloaded state

### DIFF
--- a/telegramfilehandler.cpp
+++ b/telegramfilehandler.cpp
@@ -393,6 +393,7 @@ void TelegramFileHandler::refresh()
         {
             p->telegram->getFileJustCheck(p->location);
             p->location->download()->locationChanged();
+            p->location->download()->downloadedChanged();
         }
         if(p->thumb_location)
         {
@@ -455,6 +456,12 @@ void TelegramFileHandler::dwl_locationChanged()
 
 void TelegramFileHandler::dwl_downloadedChanged()
 {
+    if(p->location && p->downloaded != p->location->download()->downloaded())
+    {
+        p->downloaded = p->location->download()->downloaded();
+        Q_EMIT downloadedChanged();
+    }
+
     Q_EMIT progressCurrentByteChanged();
     Q_EMIT progressPercentChanged();
 }

--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -2021,7 +2021,10 @@ void TelegramQml::getFileJustCheck(FileLocationObject *l)
 
     const QString & download_file = fileLocation(l);
     if( QFile::exists(download_file) && !l->download()->file()->isOpen() )
+    {
         l->download()->setLocation(FILES_PRE_STR+download_file);
+        l->download()->setDownloaded(true);
+    }
 }
 
 void TelegramQml::cancelDownload(DownloadObject *download)


### PR DESCRIPTION
I have noticed that the "downloaded" property of FileHandler is always false, but downloadedChanged() signal is emitted normally.

With this commit, the "downloaded" property is updated correctly so it is possible to check if a document/photo/audio/video messages are/was downloaded
