### PR TITLE
TelegramQml::insertDialog(): Check 'muted' state and update internal DB

### DIFF
--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -3559,6 +3559,9 @@ void TelegramQml::insertDialog(const Dialog &d, bool encrypted, bool fromDb)
         obj->setEncrypted(encrypted);
     }
 
+    if(d.notifySettings().muteUntil() > 0)
+        p->userdata->addMute(did);
+
     p->dialogs_list = p->dialogs.keys();
 
     telegramp_qml_tmp = p;


### PR DESCRIPTION
Before this commit, notification info for dialogs was out of sync with Telegram servers

Test case:
- Close your client that uses TelegramQML
- Open an official client
- Disable notifications in a dialog
- Start your TelegramQML based client
- **Notification info is not updated**

With this commit, that info is updated during initialization and calling:

```
 telegram.userData.isMuted(dId);
```

gives a valid info.
