### PR TITLE
Add user blocking/unblocking.

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -148,6 +148,18 @@ void Database::deleteHistory(qint64 dlgId)
     QMetaObject::invokeMethod(p->core, "deleteHistory", Qt::QueuedConnection, Q_ARG(qint64,dlgId));
 }
 
+void Database::blockUser(qint64 userId)
+{
+    FIRST_CHECK;
+    QMetaObject::invokeMethod(p->core, "blockUser", Qt::QueuedConnection, Q_ARG(qint64, userId));
+}
+
+void Database::unblockUser(qint64 userId)
+{
+    FIRST_CHECK;
+    QMetaObject::invokeMethod(p->core, "unblockUser", Qt::QueuedConnection, Q_ARG(qint64, userId));
+}
+
 void Database::userFounded_slt(const DbUser &user)
 {
     Q_EMIT userFounded(user.user);

--- a/database.h
+++ b/database.h
@@ -47,6 +47,9 @@ public Q_SLOTS:
     void deleteDialog(qint64 dlgId);
     void deleteHistory(qint64 dlgId);
 
+    void blockUser(qint64 userId);
+    void unblockUser(qint64 userId);
+
 Q_SIGNALS:
     void userFounded(const User &user);
     void chatFounded(const Chat &chat);

--- a/database/database.sql
+++ b/database/database.sql
@@ -136,6 +136,10 @@ CREATE TABLE IF NOT EXISTS Chats (
 );
 CREATE INDEX "Chats.title_idx" ON "Chats"("title");
 
+CREATE TABLE IF NOT EXISTS Blocked {
+    uid BIGINT PRIMARY KEY NOT NULL
+}
+
 CREATE TABLE IF NOT EXISTS Users (
     id BIGINT PRIMARY KEY NOT NULL,
     accessHash BIGINT,

--- a/databasecore.cpp
+++ b/databasecore.cpp
@@ -396,6 +396,30 @@ void DatabaseCore::deleteHistory(qint64 dlgId)
         qDebug() << __FUNCTION__ << query.lastError();
 }
 
+void DatabaseCore::blockUser(qint64 userId)
+{
+    begin();
+    QSqlQuery query(p->db);
+    query.prepare("REPLACE INTO Blocked VALUES(:uid)");
+    query.bindValue(":uid", userId);
+
+    bool res = query.exec();
+    if(!res)
+        qDebug() << __FUNCTION__ << query.lastError();
+}
+
+void DatabaseCore::unblockUser(qint64 userId)
+{
+    begin();
+    QSqlQuery query(p->db);
+    query.prepare("DELETE FROM Blocked WHERE uid = :uid");
+    query.bindValue(":uid", userId);
+
+    bool res = query.exec();
+    if(!res)
+        qDebug() << __FUNCTION__ << query.lastError();
+}
+
 void DatabaseCore::readDialogs()
 {
     QSqlQuery query(p->db);
@@ -615,6 +639,14 @@ void DatabaseCore::update_db()
         query.exec();
 
         db_version = 3;
+    }
+    if (db_version == 3)
+    {
+        QSqlQuery query(p->db);
+        query.prepare("CREATE TABLE IF NOT EXISTS Blocked (uid BIGINT PRIMARY KEY NOT NULL)");
+        query.exec();
+
+        db_version = 4;
     }
 
     setValue("version", QString::number(db_version) );

--- a/databasecore.h
+++ b/databasecore.h
@@ -42,6 +42,9 @@ public Q_SLOTS:
     void deleteDialog(qint64 dlgId);
     void deleteHistory(qint64 dlgId);
 
+    void blockUser(qint64 userId);
+    void unblockUser(qint64 userId);
+
 Q_SIGNALS:
     void userFounded(const DbUser &user);
     void chatFounded(const DbChat &chat);

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -24,6 +24,7 @@
 #include "types/inputfilelocation.h"
 #include "types/peer.h"
 #include "types/inputpeer.h"
+#include "types/inputuser.h"
 
 #include "telegramqml_global.h"
 
@@ -260,6 +261,7 @@ public:
     QList<qint64> uploads() const;
     QList<qint64> contacts() const;
 
+    InputUser getInputUser(qint64 userId) const;
     InputPeer getInputPeer(qint64 pid);
 
     QList<qint64> userIndex(const QString &keyword);
@@ -276,8 +278,12 @@ public Q_SLOTS:
     void accountRegisterDevice(const QString &token, const QString &appVersion = QString::null);
     void accountUnregisterDevice(const QString &token);
     void accountUpdateProfile(const QString &firstName, const QString &lastName);
+    void usersGetFullUser(qint64 userId);
     void accountCheckUsername(const QString &username);
     void accountUpdateUsername(const QString &username);
+
+    void contactsBlock(qint64 userId);
+    void contactsUnblock(qint64 userId);
 
     void sendMessage( qint64 dialogId, const QString & msg, int replyTo = 0 );
     bool sendMessageAsDocument( qint64 dialogId, const QString & msg );
@@ -378,6 +384,8 @@ Q_SIGNALS:
 
     void userBecomeOnline(qint64 userId);
     void userStartTyping(qint64 userId, qint64 dId);
+    void userBlocked(qint64 userId);
+    void userUnblocked(qint64 userId);
 
     void contactsImportedContacts(qint32 importedCount, qint32 retryCount);
 
@@ -417,11 +425,15 @@ private Q_SLOTS:
     void accountGetWallPapers_slt(qint64 id, const QList<WallPaper> & wallPapers);
     void accountCheckUsername_slt(qint64 id, bool ok);
     void accountUpdateUsername_slt(qint64 id, const User &user);
+
+
     void photosUploadProfilePhoto_slt(qint64 id, const Photo & photo, const QList<User> & users);
     void photosUpdateProfilePhoto_slt(qint64 id, const UserProfilePhoto & userProfilePhoto);
+
+    void contactsBlock_slt(qint64 id, bool ok);
+    void contactsUnblock_slt(qint64 id, bool ok);
     void contactsImportContacts_slt(qint64 id, const QList<ImportedContact> &importedContacts, const QList<qint64> &retryContacts, const QList<User> &users);
     void contactsFound_slt(qint64 id, const QList<ContactFound> &founds, const QList<User> &users);
-
     void contactsGetContacts_slt(qint64 id, bool modified, const QList<Contact> & contacts, const QList<User> & users);
     void usersGetFullUser_slt(qint64 id, const User &user, const ContactsLink &link, const Photo &profilePhoto, const PeerNotifySettings &notifySettings, bool blocked, const QString &realFirstName, const QString &realLastName);
 
@@ -482,6 +494,8 @@ private:
     void insertEncryptedMessage(const EncryptedMessage & emsg);
     void insertEncryptedChat(const EncryptedChat & c);
     void insertSecretChatMessage(const SecretChatMessage & sc, bool cachedMsg = false);
+    void blockUser(qint64 userId);
+    void unblockUser(qint64 userId);
 
     QString fileLocation_old( FileLocationObject *location );
     QString fileLocation_old2( FileLocationObject *location );


### PR DESCRIPTION
When showing user profile, one should call:
telegram.usersGetFullUser(user.id);
and observe telegram.onUser(Un)Blocked signals. This will work assuming you're online. We'll have to add a simple isBlocked() call later (since those values are cached in Blocked table). I'll also add querying all blocked users, etc. For now, this is simple and works fine.

One question: should I update database.sqlite with the new schema? I added upgrade code to my app to add the Blocked table. But I think I should update database.sqlite as well, right? If yes, please either do that or leave comment, I'll do it.

FWIW I think we should keep database version in the database.sqlite user_version field:
https://www.sqlite.org/pragma.html#pragma_schema_version
and not in app settings. Just a thought, we can do it later (or someone might contribute that bit in a backward compatible manner).
