### PR TITLE
Smarter history clearing with group leaving and secret discarding.

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -103,6 +103,12 @@ void Database::insertMediaEncryptedKeys(qint64 mediaId, const QByteArray &key, c
     QMetaObject::invokeMethod(p->core, "insertMediaEncryptedKeys", Qt::QueuedConnection, Q_ARG(qint64,mediaId), Q_ARG(QByteArray,key), Q_ARG(QByteArray,iv));
 }
 
+void Database::updateUnreadCount(qint64 chatId, int unreadCount)
+{
+    FIRST_CHECK;
+    QMetaObject::invokeMethod(p->core, "updateUnreadCount", Qt::QueuedConnection, Q_ARG(qint64,chatId), Q_ARG(int,unreadCount));
+}
+
 void Database::readFullDialogs()
 {
     FIRST_CHECK;

--- a/database.h
+++ b/database.h
@@ -38,6 +38,8 @@ public Q_SLOTS:
     void insertMessage(const Message &message);
     void insertMediaEncryptedKeys(qint64 mediaId, const QByteArray &key, const QByteArray &iv);
 
+    void updateUnreadCount(qint64 chatId, int unreadCount);
+
     void readFullDialogs();
     void readMessages(const Peer &peer, int offset, int limit);
     void markMessagesAsRead(const QList<qint32>& messages);

--- a/databasecore.cpp
+++ b/databasecore.cpp
@@ -234,6 +234,22 @@ void DatabaseCore::insertMediaEncryptedKeys(qint64 mediaId, const QByteArray &ke
     }
 }
 
+void DatabaseCore::updateUnreadCount(qint64 chatId, int unreadCount)
+{
+    begin();
+    QSqlQuery query(p->db);
+    query.prepare("UPDATE Dialogs SET unreadCount=:unreadCount WHERE peer=:chatId;");
+    query.bindValue(":unreadCount", unreadCount);
+    query.bindValue(":chatId", chatId);
+
+    bool res = query.exec();
+    if(!res)
+    {
+        qDebug() << __FUNCTION__ << query.lastError();
+        return;
+    }
+}
+
 void DatabaseCore::readFullDialogs()
 {
     readUsers();

--- a/databasecore.h
+++ b/databasecore.h
@@ -30,6 +30,8 @@ public Q_SLOTS:
     void insertMessage(const DbMessage &message);
     void insertMediaEncryptedKeys(qint64 mediaId, const QByteArray &key, const QByteArray &iv);
 
+    void updateUnreadCount(qint64 chatId, int unreadCount);
+
     void readFullDialogs();
     void readMessages(const DbPeer &peer, int offset, int limit);
     void markMessagesAsRead(const QList<qint32>& messages);

--- a/telegrammessagesmodel.cpp
+++ b/telegrammessagesmodel.cpp
@@ -245,16 +245,17 @@ void TelegramMessagesModel::setReaded()
     if( p->telegram->invisible() )
         return;
 
+    p->dialog->setUnreadCount(0);
     qint32 topMessageId = p->dialog->topMessage();
-    const MessageObject* message = p->telegram->message(topMessageId);
+    if (topMessageId == 0) return;
 
+    const MessageObject* message = p->telegram->message(topMessageId);
     if(!message) {
         qDebug() << __FUNCTION__ << ": Can't find message with id: " << topMessageId;
         return;
     }
 
     p->telegram->messagesReadHistory(peerId(), message->date());
-    p->dialog->setUnreadCount(0);
 }
 
 void TelegramMessagesModel::clearNewMessageFlag()

--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -4243,9 +4243,6 @@ void TelegramQml::deleteLocalHistory(qint64 peerId) {
             insertToGarbeges(p->messages.value(msgId));
         }
     }
-    if (deleteDialog) {
-        p->messages_list.remove(peerId);
-    }
     Q_EMIT messagesChanged(false);
 
     if (deleteDialog) {

--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -4236,11 +4236,11 @@ void TelegramQml::deleteLocalHistory(qint64 peerId) {
     const QList<qint64> & messages = p->messages_list.value(peerId);
     if (isEncrypted) {
         Q_FOREACH(qint64 msgId, messages) {
-            insertToGarbeges(p->encmessages.take(msgId));
+            insertToGarbeges(p->encmessages.value(msgId));
         }
     } else {
         Q_FOREACH(qint64 msgId, messages) {
-            insertToGarbeges(p->messages.take(msgId));
+            insertToGarbeges(p->messages.value(msgId));
         }
     }
     if (deleteDialog) {
@@ -4250,9 +4250,9 @@ void TelegramQml::deleteLocalHistory(qint64 peerId) {
 
     if (deleteDialog) {
         p->database->deleteDialog(peerId);
-        insertToGarbeges(p->chats.take(peerId));
-        insertToGarbeges(p->encchats.take(peerId));
-        insertToGarbeges(p->dialogs.take(peerId));
+        insertToGarbeges(p->chats.value(peerId));
+        insertToGarbeges(p->encchats.value(peerId));
+        insertToGarbeges(p->dialogs.value(peerId));
         Q_EMIT dialogsChanged(false);
     }
 

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -298,17 +298,17 @@ public Q_SLOTS:
     void deleteCutegramDialog();
     void messagesCreateChat(const QList<int> &users, const QString & topic );
     void messagesAddChatUser(qint64 chatId, qint64 userId, qint32 fwdLimit = 0);
-    void messagesDeleteChatUser(qint64 chatId, qint64 userId);
+    qint64 messagesDeleteChatUser(qint64 chatId, qint64 userId);
     void messagesEditChatTitle(qint32 chatId, const QString &title);
     void messagesEditChatPhoto(qint32 chatId, const QString &filePath);
 
-    void messagesDeleteHistory(qint64 peerId);
+    void messagesDeleteHistory(qint64 peerId, bool deleteChat = true, bool userRemoved = false);
     void messagesSetTyping(qint64 peerId, bool stt);
     void messagesReadHistory(qint64 peerId, qint32 maxDate = 0);
 
     void messagesCreateEncryptedChat(qint64 userId);
     void messagesAcceptEncryptedChat(qint32 chatId);
-    void messagesDiscardEncryptedChat(qint32 chatId);
+    qint64 messagesDiscardEncryptedChat(qint32 chatId);
 
     void messagesGetFullChat(qint32 chatId);
 
@@ -494,6 +494,7 @@ private:
     void insertEncryptedMessage(const EncryptedMessage & emsg);
     void insertEncryptedChat(const EncryptedChat & c);
     void insertSecretChatMessage(const SecretChatMessage & sc, bool cachedMsg = false);
+    void deleteLocalHistory(qint64 peerId);
     void blockUser(qint64 userId);
     void unblockUser(qint64 userId);
 

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -302,9 +302,9 @@ public Q_SLOTS:
     void messagesEditChatTitle(qint32 chatId, const QString &title);
     void messagesEditChatPhoto(qint32 chatId, const QString &filePath);
 
-    void messagesDeleteHistory(qint64 peerId, bool deleteChat = true, bool userRemoved = false);
+    void messagesDeleteHistory(qint64 peerId, bool deleteChat = false, bool userRemoved = false);
     void messagesSetTyping(qint64 peerId, bool stt);
-    void messagesReadHistory(qint64 peerId, qint32 maxDate = 0);
+    qint64 messagesReadHistory(qint64 peerId, qint32 maxDate = 0);
 
     void messagesCreateEncryptedChat(qint64 userId);
     void messagesAcceptEncryptedChat(qint32 chatId);
@@ -450,6 +450,7 @@ private Q_SLOTS:
     void messagesSendDocument_slt(qint64 id, const Message & message, const QList<Chat> & chats, const QList<User> & users, const QList<ContactsLink> & links, qint32 pts, qint32 seq);
     void messagesGetDialogs_slt(qint64 id, qint32 sliceCount, const QList<Dialog> & dialogs, const QList<Message> & messages, const QList<Chat> & chats, const QList<User> & users);
     void messagesGetHistory_slt(qint64 id, qint32 sliceCount, const QList<Message> & messages, const QList<Chat> & chats, const QList<User> & users);
+    void messagesReadHistory_slt(qint64 id, qint32 pts, qint32 pts_count, qint32 offset);
     void messagesDeleteHistory_slt(qint64 id, qint32 pts, qint32 seq, qint32 offset);
 
     void messagesSearch_slt(qint64 id, qint32 sliceCount, const QList<Message> & messages, const QList<Chat> & chats, const QList<User> & users);


### PR DESCRIPTION
When clearing history, an boolean can be passed (I picked sensible defaults for Cutegram) to also request dialog deletion.

Full paths for deleting a dialog using messagesDeleteHistory(peerId, [true]) are as follows:
group chat: [ leave group ] -> clear history -> delete dialog
1-1 chat: clear history -> delete dialog
secret: clear local history -> delete dialog

For clearing history using messagesDeleteHistory(peerId, false):
group and 1-1: clear-history
secret: clear local history

I noticed a couple issues, I'd like to hear your opinion on:
- marking messages as read in secret chats still doesn't work
- clearing history leaves ghost messages in messages list (did I miss something?)
- I also noticed in latest Cutegram a new secret chat appears at the top, which is not the case with the 'old' version of TelegramQML. Unless there's an easy fix, I would have to enable autoAcceptEncrypted for time being, so that the first "foo created secret chat" pushes the dialog to the top.

Please comment, thanks.
