### PR TITLE
Add media type support to the SecretChat

### DIFF
--- a/objects/types.h
+++ b/objects/types.h
@@ -2114,8 +2114,6 @@ class TELEGRAMQMLSHARED_EXPORT DocumentObject : public TqObject
     Q_PROPERTY(QList<DocumentAttribute> attributes READ attributes WRITE setAttributes NOTIFY attributesChanged)
     Q_PROPERTY(qint64 accessHash READ accessHash WRITE setAccessHash NOTIFY accessHashChanged)
     Q_PROPERTY(qint32 size READ size WRITE setSize NOTIFY sizeChanged)
-    Q_PROPERTY(QByteArray encryptKey READ encryptKey WRITE setEncryptKey NOTIFY encryptKeyChanged)
-    Q_PROPERTY(QByteArray encryptIv READ encryptIv WRITE setEncryptIv NOTIFY encryptIvChanged)
     Q_PROPERTY(quint32 classType READ classType WRITE setClassType NOTIFY classTypeChanged)
 
 public:
@@ -2129,8 +2127,6 @@ public:
         _attributes = another.attributes();
         _accessHash = another.accessHash();
         _size = another.size();
-        _encryptKey = QByteArray();
-        _encryptIv = QByteArray();
         _classType = another.classType();
 
     }
@@ -2231,30 +2227,6 @@ public:
         Q_EMIT changed();
     }
 
-    QByteArray encryptKey() const {
-        return _encryptKey;
-    }
-
-    void setEncryptKey(QByteArray value) {
-        if( value == _encryptKey )
-            return;
-        _encryptKey = value;
-        Q_EMIT encryptKeyChanged();
-        Q_EMIT changed();
-    }
-
-    QByteArray encryptIv() const {
-        return _encryptIv;
-    }
-
-    void setEncryptIv(QByteArray value) {
-        if( value == _encryptIv )
-            return;
-        _encryptIv = value;
-        Q_EMIT encryptIvChanged();
-        Q_EMIT changed();
-    }
-
     quint32 classType() const {
         return _classType;
     }
@@ -2299,8 +2271,6 @@ Q_SIGNALS:
     void attributesChanged();
     void accessHashChanged();
     void sizeChanged();
-    void encryptKeyChanged();
-    void encryptIvChanged();
     void classTypeChanged();
 
 private:
@@ -2313,8 +2283,6 @@ private:
     qint64 _accessHash;
     qint32 _userId;
     qint32 _size;
-    QByteArray _encryptKey;
-    QByteArray _encryptIv;
     quint32 _classType;
 
 };
@@ -4379,6 +4347,8 @@ class TELEGRAMQMLSHARED_EXPORT MessageMediaObject : public TqObject
     Q_PROPERTY(QString phoneNumber READ phoneNumber WRITE setPhoneNumber NOTIFY phoneNumberChanged)
     Q_PROPERTY(qint32 userId READ userId WRITE setUserId NOTIFY userIdChanged)
     Q_PROPERTY(VideoObject* video READ video WRITE setVideo NOTIFY videoChanged)
+    Q_PROPERTY(QByteArray encryptKey READ encryptKey WRITE setEncryptKey NOTIFY encryptKeyChanged)
+    Q_PROPERTY(QByteArray encryptIv READ encryptIv WRITE setEncryptIv NOTIFY encryptIvChanged)
     Q_PROPERTY(quint32 classType READ classType WRITE setClassType NOTIFY classTypeChanged)
 
 public:
@@ -4394,6 +4364,8 @@ public:
         _phoneNumber = another.phoneNumber();
         _userId = another.userId();
         _video = new VideoObject(another.video(), this);
+        _encryptKey = QByteArray();
+        _encryptIv = QByteArray();
         _classType = another.classType();
 
     }
@@ -4520,6 +4492,30 @@ public:
         Q_EMIT changed();
     }
 
+    QByteArray encryptKey() const {
+        return _encryptKey;
+    }
+
+    void setEncryptKey(QByteArray value) {
+        if( value == _encryptKey )
+            return;
+        _encryptKey = value;
+        Q_EMIT encryptKeyChanged();
+        Q_EMIT changed();
+    }
+
+    QByteArray encryptIv() const {
+        return _encryptIv;
+    }
+
+    void setEncryptIv(QByteArray value) {
+        if( value == _encryptIv )
+            return;
+        _encryptIv = value;
+        Q_EMIT encryptIvChanged();
+        Q_EMIT changed();
+    }
+
     quint32 classType() const {
         return _classType;
     }
@@ -4571,6 +4567,8 @@ Q_SIGNALS:
     void phoneNumberChanged();
     void userIdChanged();
     void videoChanged();
+    void encryptKeyChanged();
+    void encryptIvChanged();
     void classTypeChanged();
 
 private:
@@ -4584,6 +4582,8 @@ private:
     QString _phoneNumber;
     qint32 _userId;
     VideoObject* _video;
+    QByteArray _encryptKey;
+    QByteArray _encryptIv;
     quint32 _classType;
 
 };

--- a/telegramfilehandler.cpp
+++ b/telegramfilehandler.cpp
@@ -660,9 +660,12 @@ FileLocationObject *TelegramFileHandler::analizeObject(QObject *target, int *tar
         break;
 
     case TypeObjectPhoto:
-        object = static_cast<PhotoObject*>(target)->sizes();
+    {
+        object = p->telegram->locationOfPhoto( static_cast<PhotoObject*>(target) );
+        p->thumb_location = p->telegram->locationOfThumbPhoto(static_cast<PhotoObject*>(target) );
         if(targetType) *targetType = TypeTargetMediaPhoto;
         if(targetPointer) *targetPointer = static_cast<PhotoObject*>(target);
+    }
         break;
 
     case TypeObjectPhotoSizeList:

--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -794,6 +794,67 @@ FileLocationObject *TelegramQml::locationOf(qint64 id, qint64 dcId, qint64 acces
     return obj;
 }
 
+FileLocationObject *TelegramQml::locationOfPhoto(PhotoObject *photo)
+{
+    PhotoSizeList *list = photo->sizes();
+    QObject *parent = photo;
+    if(list->count())
+    {
+        int maxIdx = 0,
+            maxSize = 0;
+
+        for(int i=0; i<list->count(); i++)
+        {
+            PhotoSizeObject *size = list->at(i);
+            if(maxSize == 0)
+                maxSize = size->w();
+            else
+            if(size->w() >= maxSize)
+            {
+                maxIdx = i;
+                maxSize = size->w();
+            }
+        }
+
+        FileLocationObject *location = list->at(maxIdx)->location();
+        if(location->volumeId())
+            return location;
+
+        parent = list->at(maxIdx);
+    }
+
+    return locationOf(photo->id(), 0, photo->accessHash(), parent);
+}
+
+FileLocationObject *TelegramQml::locationOfThumbPhoto(PhotoObject *photo)
+{
+    PhotoSizeList *list = photo->sizes();
+    if(list->count())
+    {
+        int minIdx = 0,
+            minSize = 0;
+
+        for(int i=0; i<list->count(); i++)
+        {
+            PhotoSizeObject *size = list->at(i);
+            if(minSize == 0)
+                minSize = size->w();
+            else
+            if(size->w() <= minSize)
+            {
+                minIdx = i;
+                minSize = size->w();
+            }
+        }
+
+        FileLocationObject *location = list->at(minIdx)->location();
+        if(location->volumeId())
+            return location;
+    }
+
+    return 0;
+}
+
 FileLocationObject *TelegramQml::locationOfDocument(DocumentObject *doc)
 {
     FileLocationObject *res = locationOf(doc->id(), doc->dcId(), doc->accessHash(), doc);
@@ -1870,7 +1931,7 @@ bool TelegramQml::sendFile(qint64 dId, const QString &fpath, bool forceDocument,
         thumbnail.clear();
     }
 
-    if( (t.name().contains("webp") || fpath.right(5) == ".webp") && !dlg->encrypted() && !forceDocument && !forceAudio && !dlg->encrypted() )
+    if( (t.name().contains("webp") || fpath.right(5) == ".webp") && !dlg->encrypted() && !forceDocument && !forceAudio )
     {
         QImageReader reader(file);
         const QSize imageSize = reader.size();
@@ -2009,16 +2070,28 @@ void TelegramQml::getFile(FileLocationObject *l, qint64 type, qint32 fileSize)
 
     QByteArray ekey;
     QByteArray eiv;
+
     QObject *parentObj = l->parent();
+    MessageMediaObject *media = 0;
+    while(parentObj)
+    {
+        parentObj = parentObj->parent();
+        media = qobject_cast<MessageMediaObject*>(parentObj);
+        if(media)
+            break;
+    }
+
+    if(media && !media->encryptKey().isEmpty())
+    {
+        ekey = media->encryptKey();
+        eiv  = media->encryptIv();
+        input.setClassType(InputFileLocation::typeInputEncryptedFileLocation);
+    }
+
+    parentObj = l->parent();
     if(parentObj && qobject_cast<DocumentObject*>(parentObj))
     {
         DocumentObject *doc = static_cast<DocumentObject*>(parentObj);
-        if( !doc->encryptKey().isEmpty() )
-        {
-            ekey = doc->encryptKey();
-            eiv  = doc->encryptIv();
-            input.setClassType(InputFileLocation::typeInputEncryptedFileLocation);
-        }
         l->download()->setTotal(doc->size());
     }
     else
@@ -3380,15 +3453,69 @@ void TelegramQml::messagesSendEncryptedFile_slt(qint64 id, qint32 date, const En
     dialog.setTopMessage(date);
     dialog.setUnreadCount(0);
 
-    Document document(Document::typeDocument);
-    document.setAccessHash(encryptedFile.accessHash());
-    document.setId(encryptedFile.id());
-    document.setDate(date);
-    document.setSize(encryptedFile.size());
-    document.setDcId(encryptedFile.dcId());
+    MessageMediaObject *mediaObj = msgObj->media();
+    MessageMedia media( static_cast<MessageMedia::MessageMediaType>(mediaObj->classType()) );
+    switch(mediaObj->classType())
+    {
+    case MessageMedia::typeMessageMediaPhoto:
+    {
+        QImageReader reader(srcFile);
 
-    MessageMedia media(MessageMedia::typeMessageMediaDocument);
-    media.setDocument(document);
+        PhotoSize psize(PhotoSize::typePhotoSize);
+        psize.setH(reader.size().height());
+        psize.setW(reader.size().width());
+        psize.setSize(QFileInfo(srcFile).size());
+
+        Photo photo(Photo::typePhoto);
+        photo.setAccessHash(encryptedFile.accessHash());
+        photo.setId(encryptedFile.id());
+        photo.setDate(date);
+        photo.setUserId(me());
+        photo.setSizes( QList<PhotoSize>()<<psize );
+
+        media.setPhoto(photo);
+    }
+        break;
+
+    case MessageMedia::typeMessageMediaVideo:
+    {
+        Video video(Video::typeVideo);
+        video.setAccessHash(encryptedFile.accessHash());
+        video.setId(encryptedFile.id());
+        video.setDate(date);
+        video.setSize(encryptedFile.size());
+        video.setDcId(encryptedFile.dcId());
+        video.setW(640);
+        video.setH(400);
+        media.setVideo(video);
+    }
+        break;
+
+    case MessageMedia::typeMessageMediaAudio:
+    {
+        Audio audio(Audio::typeAudio);
+        audio.setAccessHash(encryptedFile.accessHash());
+        audio.setId(encryptedFile.id());
+        audio.setDate(date);
+        audio.setSize(encryptedFile.size());
+        audio.setDcId(encryptedFile.dcId());
+        media.setAudio(audio);
+    }
+        break;
+
+    default:
+    case MessageMedia::typeMessageMediaDocument:
+    {
+        Document document(Document::typeDocument);
+        document.setAccessHash(encryptedFile.accessHash());
+        document.setId(encryptedFile.id());
+        document.setDate(date);
+        document.setSize(encryptedFile.size());
+        document.setDcId(encryptedFile.dcId());
+        media.setDocument(document);
+    }
+        break;
+    }
 
     Message msg(Message::typeMessage);
     msg.setFromId(msgObj->fromId());
@@ -3981,7 +4108,9 @@ void TelegramQml::insertUpdate(const Update &update)
         insertMessage(update.message(), false, false, true);
         timerUpdateDialogs(3000);
 
+#ifdef UBUNTU_PHONE
         Q_EMIT messagesReceived(1);
+#endif
         break;
 
     case Update::typeUpdateContactLink:
@@ -4229,29 +4358,121 @@ void TelegramQml::insertSecretChatMessage(const SecretChatMessage &sc, bool cach
     bool hasInternalMedia = false;
     if(hasMedia)
     {
-        Document doc(Document::typeDocument);
+        MessageMedia media(MessageMedia::typeMessageMediaEmpty);
         if(dmedia.classType() == DecryptedMessageMedia::typeDecryptedMessageMediaExternalDocument)
         {
+            Document doc(Document::typeDocument);
             doc.setAccessHash(dmedia.accessHash());
             doc.setSize(dmedia.size());
             doc.setDcId(dmedia.dcId());
             doc.setId(dmedia.id());
             doc.setMimeType(dmedia.mimeType());
-            doc.setThumb(dmedia.thumb23());
+            doc.setThumb( insertCachedPhotoSize(dmedia.thumb23()) );
             doc.setDate(dmedia.date());
             doc.setAttributes(dmedia.attributes());
+
+            media.setDocument(doc);
+            media.setClassType(MessageMedia::typeMessageMediaDocument);
+        }
+        else
+        if(dmedia.classType() == DecryptedMessageMedia::typeDecryptedMessageMediaPhoto)
+        {
+            QList<PhotoSize> photoSizes;
+
+            PhotoSize psize(PhotoSize::typePhotoSize);
+            psize.setSize(dmedia.size());
+            psize.setW(dmedia.w());
+            psize.setH(dmedia.h());
+            photoSizes << psize;
+
+            PhotoSize thumbSize(PhotoSize::typePhotoSize);
+            if(dmedia.thumb23().classType() != PhotoSize::typePhotoSizeEmpty)
+            {
+                thumbSize = dmedia.thumb23();
+                thumbSize.setW(dmedia.w());
+                thumbSize.setH(dmedia.h());
+            }
+            else
+            {
+                thumbSize.setClassType(PhotoSize::typePhotoCachedSize);
+                thumbSize.setBytes(dmedia.thumb());
+                thumbSize.setW(dmedia.w()/2);
+                thumbSize.setH(dmedia.h()/2);
+
+                thumbSize = insertCachedPhotoSize(thumbSize);
+            }
+
+            if(thumbSize.classType() == PhotoSize::typePhotoSize)
+                photoSizes << thumbSize;
+
+            Photo photo(Photo::typePhoto);
+            photo.setId(attachment.id());
+            photo.setAccessHash(attachment.accessHash());
+            photo.setUserId(msg.fromId());
+            photo.setDate(msg.date());
+            photo.setSizes(QList<PhotoSize>()<<photoSizes);
+
+            media.setPhoto(photo);
+            media.setClassType(MessageMedia::typeMessageMediaPhoto);
+
+            hasInternalMedia = true;
+        }
+        else
+        if(dmedia.classType() == DecryptedMessageMedia::typeDecryptedMessageMediaVideo ||
+           dmedia.classType() == DecryptedMessageMedia::typeDecryptedMessageMediaVideo_layer8)
+        {
+            Video video(Video::typeVideo);
+            video.setId(attachment.id());
+            video.setDcId(attachment.dcId());
+            video.setAccessHash(attachment.accessHash());
+            video.setDate(msg.date());
+            video.setUserId(msg.fromId());
+            video.setSize(dmedia.size());
+            video.setH(dmedia.h());
+            video.setW(dmedia.w());
+            video.setDuration(dmedia.duration());
+
+            if(dmedia.classType() == DecryptedMessageMedia::typeDecryptedMessageMediaVideo_layer8)
+            {
+                PhotoSize thumbSize(PhotoSize::typePhotoCachedSize);
+                thumbSize.setBytes(dmedia.thumb());
+                thumbSize.setW(dmedia.w());
+                thumbSize.setH(dmedia.h());
+                video.setThumb( insertCachedPhotoSize(thumbSize) );
+            }
+
+            media.setVideo(video);
+            media.setClassType(MessageMedia::typeMessageMediaVideo);
+
+            hasInternalMedia = true;
+        }
+        else
+        if(dmedia.classType() == DecryptedMessageMedia::typeDecryptedMessageMediaAudio ||
+           dmedia.classType() == DecryptedMessageMedia::typeDecryptedMessageMediaAudio_layer8)
+        {
+            Audio audio(Audio::typeAudio);
+            audio.setId(attachment.id());
+            audio.setDcId(attachment.dcId());
+            audio.setAccessHash(attachment.accessHash());
+            audio.setDate(msg.date());
+            audio.setUserId(msg.fromId());
+            audio.setSize(dmedia.size());
+            audio.setDuration(dmedia.duration());
+
+            media.setAudio(audio);
+            media.setClassType(MessageMedia::typeMessageMediaAudio);
+
+            hasInternalMedia = true;
         }
         else
         {
+            Document doc(Document::typeDocument);
             doc.setAccessHash(attachment.accessHash());
             doc.setId(attachment.id());
             doc.setDcId(attachment.dcId());
             doc.setSize(attachment.size());
             hasInternalMedia = true;
         }
-
-        MessageMedia media(MessageMedia::typeMessageMediaDocument);
-        media.setDocument(doc);
 
         msg.setMedia(media);
     }
@@ -4261,8 +4482,8 @@ void TelegramQml::insertSecretChatMessage(const SecretChatMessage &sc, bool cach
     MessageObject *msgObj = p->messages.value(msg.id());
     if(msgObj && hasInternalMedia)
     {
-        msgObj->media()->document()->setEncryptKey(dmedia.key());
-        msgObj->media()->document()->setEncryptIv(dmedia.iv());
+        msgObj->media()->setEncryptKey(dmedia.key());
+        msgObj->media()->setEncryptIv(dmedia.iv());
 
         p->database->insertMediaEncryptedKeys(msg.id(), dmedia.key(), dmedia.iv());
     }
@@ -4284,6 +4505,40 @@ void TelegramQml::insertSecretChatMessage(const SecretChatMessage &sc, bool cach
     }
 
     insertDialog(dlg, true);
+}
+
+PhotoSize TelegramQml::insertCachedPhotoSize(const PhotoSize &photo)
+{
+    PhotoSize result(PhotoSize::typePhotoSize);
+    if(photo.classType() != PhotoSize::typePhotoCachedSize || photo.bytes().isEmpty())
+        return photo;
+
+    FileLocation location(FileLocation::typeFileLocation);
+    location.setVolumeId(generateRandomId());
+    location.setLocalId(generateRandomId());
+    location.setSecret(generateRandomId());
+    location.setDcId(0);
+
+    FileLocationObject locObj(location.classType());
+    locObj.setVolumeId(location.volumeId());
+    locObj.setLocalId(location.localId());
+    locObj.setSecret(location.secret());
+    locObj.setDcId(location.dcId());
+
+    const QString &path = fileLocation(&locObj);
+    QFile file(path);
+    if(!file.open(QFile::WriteOnly))
+        return photo;
+
+    file.write(photo.bytes());
+    file.close();
+
+    result.setH(photo.h());
+    result.setW(photo.w());
+    result.setSize(photo.bytes().length());
+    result.setLocation(location);
+
+    return result;
 }
 
 void TelegramQml::blockUser(qint64 userId)
@@ -4486,8 +4741,8 @@ void TelegramQml::dbMediaKeysFounded(qint64 mediaId, const QByteArray &key, cons
     if(!msg)
         return;
 
-    msg->media()->document()->setEncryptKey(key);
-    msg->media()->document()->setEncryptIv(iv);
+    msg->media()->setEncryptKey(key);
+    msg->media()->setEncryptIv(iv);
 }
 
 void TelegramQml::refreshUnreadCount()

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -29,6 +29,7 @@
 
 #include "telegramqml_global.h"
 
+class PhotoSize;
 class TelegramSearchModel;
 class UpdatesState;
 class NewsLetterDialog;
@@ -232,6 +233,8 @@ public:
     Q_INVOKABLE EncryptedChatObject *encryptedChat(qint64 id) const;
 
     Q_INVOKABLE FileLocationObject *locationOf(qint64 id, qint64 dcId, qint64 accessHash, QObject *parent);
+    Q_INVOKABLE FileLocationObject *locationOfPhoto(PhotoObject *photo);
+    Q_INVOKABLE FileLocationObject *locationOfThumbPhoto(PhotoObject *photo);
     Q_INVOKABLE FileLocationObject *locationOfDocument(DocumentObject *doc);
     Q_INVOKABLE FileLocationObject *locationOfVideo(VideoObject *vid);
     Q_INVOKABLE FileLocationObject *locationOfAudio(AudioObject *aud);
@@ -503,6 +506,7 @@ private:
     void insertEncryptedMessage(const EncryptedMessage & emsg);
     void insertEncryptedChat(const EncryptedChat & c);
     void insertSecretChatMessage(const SecretChatMessage & sc, bool cachedMsg = false);
+    PhotoSize insertCachedPhotoSize(const PhotoSize &photo);
     void deleteLocalHistory(qint64 peerId);
     void blockUser(qint64 userId);
     void unblockUser(qint64 userId);

--- a/telegramthumbnailercore.cpp
+++ b/telegramthumbnailercore.cpp
@@ -17,6 +17,11 @@
 
 #include "telegramthumbnailercore.h"
 
+#include <QFileInfo>
+#include <QProcess>
+#include <QStringList>
+#include <QImage>
+
 #ifdef UBUNTU_PHONE
 #include <stdexcept>
 #include <QDebug>
@@ -76,7 +81,7 @@ void TelegramThumbnailerCore::createThumbnail(QString source, QString dest) {
 #ifdef Q_OS_MAC
     ffmpegPath = QCoreApplication::applicationDirPath() + "/ffmpeg";
 #else
-    if (!QFileInfo::exists(ffmpegPath) {
+    if (!QFileInfo::exists(ffmpegPath)) {
         if(QFileInfo::exists("/usr/bin/avconv"))
             ffmpegPath = "/usr/bin/avconv";
         else
@@ -87,12 +92,12 @@ void TelegramThumbnailerCore::createThumbnail(QString source, QString dest) {
 
     QStringList args;
     args << "-itsoffset" << "-4";
-    args << "-i" << video;
+    args << "-i" << source;
     args << "-vcodec" << "mjpeg";
     args << "-vframes" << "1";
     args << "-an";
     args << "-f" << "rawvideo";
-    args << output;
+    args << dest;
     args << "-y";
 
     QProcess prc;


### PR DESCRIPTION
Add Audio, Video and photo media support, to the send and received secret chat messages.
Also this commit has some compile error fix on the thumbnailerCore.
