### PR TITLE
Api25 improvements

### DIFF
--- a/profilesmodel.h
+++ b/profilesmodel.h
@@ -76,6 +76,7 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void save( const QString & key );
+    bool purge(const QString &number);
 
 private:
     void refresh();

--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -2595,6 +2595,7 @@ void TelegramQml::authLoggedIn_slt()
     Q_EMIT meChanged();
 
     QTimer::singleShot(1000, this, SLOT(updatesGetState()));
+    timerUpdateContacts(1000);
 //    p->telegram->accountUpdateStatus(!p->online || p->invisible);
 }
 

--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -2665,6 +2665,14 @@ void TelegramQml::authCheckPhone_slt(qint64 id, bool phoneRegistered)
     }
 }
 
+void TelegramQml::reconnect()
+{
+    if (p->telegram) {
+        p->telegram->sleep();
+        p->telegram->wake();
+    }
+}
+
 void TelegramQml::accountGetPassword_slt(qint64 id, const AccountPassword &password)
 {
     Q_UNUSED(id)

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -214,6 +214,8 @@ public:
 
     Q_INVOKABLE void authCheckPhone(const QString &phone);
 
+    Q_INVOKABLE void reconnect();
+
     Q_INVOKABLE void mute(qint64 peerId);
     Q_INVOKABLE void unmute(qint64 peerId);
     void accountUpdateNotifySettings(qint64 peerId, qint32 muteUntil);

--- a/telegramqml.h
+++ b/telegramqml.h
@@ -411,7 +411,7 @@ Q_SIGNALS:
     void messagesReceived(qint32 count);
 #endif
 
-    void errorSignal(qint64 id, qint32 errorCode, QString functionName, QString errorText);
+    void errorSignal(qint64 id, qint32 errorCode, QString errorText, QString functionName);
 
 protected:
     void try_init();

--- a/telegramqml.pro
+++ b/telegramqml.pro
@@ -1,6 +1,6 @@
 TEMPLATE = lib
 TARGET = telegramqml
-CONFIG += qt no_keywords c++11
+CONFIG += qt no_keywords c++11 console
 QT += qml quick sql xml multimedia
 DEFINES += TELEGRAMQML_LIBRARY
 


### PR DESCRIPTION
- When invalid phone is provided, we should handle profile directory removal.
- This also involved fixing the errorSignal signature in the header file.
- I also surfaced a reconnect() method (making use of sleep and wake, that are already present in libqtelegram) which is useful to force a reconnect on unreliable connections. For instance, we use it if the app is put to foreground and it was SIGSTOP'ed for 10 seconds, as we've noticed the connection is not reliable since we stopped using the "sleep" method (we didn't want to prematurely disconnect even though we only have a short time before the app is SIGSTOP'ed).
- I accidentally sneaked this line in:
  timerUpdateContacts(1000);
  after the user has signed in. You don't have to merge it to master if we find a better solution.
