### PR TITLE
Fixed setLogLevel() function

### DIFF
--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -756,17 +756,17 @@ void TelegramQml::setLogLevel(int level)
     switch(level)
     {
     case LogLevelClean:
-        qputenv("QT_LOGGING_RULES", "tg.*=false");
+        QLoggingCategory::setFilterRules("tg.*=false");
         break;
 
     case LogLevelUseful:
-        qputenv("QT_LOGGING_RULES", "tg.core.settings=false\n"
-                                    "tg.core.outboundpkt=false\n"
-                                    "tg.core.inboundpkt=false");
+        QLoggingCategory::setFilterRules("tg.core.settings=false\n"
+                                         "tg.core.outboundpkt=false\n"
+                                         "tg.core.inboundpkt=false");
         break;
 
     case LogLevelFull:
-        qputenv("QT_LOGGING_RULES", "");
+        QLoggingCategory::setFilterRules(QString());
         break;
     }
 }


### PR DESCRIPTION
qputenv() doesn't honor logging levels (Full/Useful/Clean)
I have replaced that function with QLoggingCategory::setFilterRules() static method which works very well :)
