### PR TITLE
delayed models data got from server until main socket becomes connected

### DIFF
--- a/telegramdetailedcontactsmodel.cpp
+++ b/telegramdetailedcontactsmodel.cpp
@@ -52,6 +52,7 @@ void TelegramDetailedContactsModel::setTelegram(TelegramQml *tgo)
     {
         disconnect(p->telegram, SIGNAL(contactsChanged()), this, SLOT(contactsChanged()));
         disconnect(p->telegram, SIGNAL(authLoggedInChanged()), this, SLOT(recheck()));
+        disconnect(p->telegram, SIGNAL(connectedChanged()), this, SLOT(recheck()));
     }
 
     p->telegram = tgo;
@@ -59,6 +60,7 @@ void TelegramDetailedContactsModel::setTelegram(TelegramQml *tgo)
     {
         connect(p->telegram, SIGNAL(contactsChanged()), this, SLOT(contactsChanged()));
         connect(p->telegram, SIGNAL(authLoggedInChanged()), this, SLOT(recheck()), Qt::QueuedConnection);
+        connect(p->telegram, SIGNAL(connectedChanged()), this, SLOT(recheck()), Qt::QueuedConnection);
     }
 
     refresh();
@@ -172,7 +174,7 @@ void TelegramDetailedContactsModel::recheck()
     if( !p->telegram || !p->telegram->authLoggedIn() )
         return;
     Telegram *tg = p->telegram->telegram();
-    if(tg)
+    if(tg && tg->isConnected())
         tg->contactsGetContacts();
 }
 

--- a/telegramdialogsmodel.cpp
+++ b/telegramdialogsmodel.cpp
@@ -66,6 +66,7 @@ void TelegramDialogsModel::setTelegram(TelegramQml *tgo)
         disconnect( p->telegram->userData(), SIGNAL(valueChanged(QString)), this, SLOT(userDataChanged()) );
 
         disconnect(p->telegram, SIGNAL(authLoggedInChanged()), this, SLOT(recheck()));
+        disconnect(p->telegram, SIGNAL(connectedChanged), this, SLOT(recheck()));
     }
 
     p->telegram = tgo;
@@ -79,6 +80,7 @@ void TelegramDialogsModel::setTelegram(TelegramQml *tgo)
         connect( p->telegram->userData(), SIGNAL(valueChanged(QString)), this, SLOT(userDataChanged()) );
 
         connect(p->telegram, SIGNAL(authLoggedInChanged()), this, SLOT(recheck()), Qt::QueuedConnection);
+        connect(p->telegram, SIGNAL(connectedChanged), this, SLOT(recheck()), Qt::QueuedConnection);
     }
 
     recheck();
@@ -196,7 +198,7 @@ void TelegramDialogsModel::recheck()
         return;
 
     Telegram *tgObject = p->telegram->telegram();
-    if(tgObject)
+    if(tgObject && tgObject->isConnected())
         tgObject->messagesGetDialogs(0,0,1000);
 }
 

--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -2620,6 +2620,9 @@ void TelegramQml::updatesGetState()
     if(!p->telegram)
         return;
 
+    if (!p->telegram->isConnected())
+        return;
+
     p->telegram->updatesGetState();
 }
 
@@ -5153,8 +5156,9 @@ void TelegramQml::timerEvent(QTimerEvent *e)
 {
     if( e->timerId() == p->upd_dialogs_timer )
     {
-        if( p->telegram )
+        if( p->telegram && p->telegram->isConnected() ) {
             p->telegram->messagesGetDialogs(0,0,1000);
+        }
 
         killTimer(p->upd_dialogs_timer);
         p->upd_dialogs_timer = 0;


### PR DESCRIPTION
- Avoid requesting for history differences, contacts, dialogs or read history if socket is still not connected
- Added signals to request those operations when socket becomes connected.
  All this prevents socket to become unusable.

This pull request should be landed along with 
https://code.launchpad.net/~rmescandon/telegram-app/updates-when-connected/+merge/286036
and 
https://github.com/Aseman-Land/libqtelegram-aseman-edition/pull/32

to solve the updates not received after connecting the socket bug
