### PR TITLE
Fixing gcc error with c++11 syntax

### DIFF
--- a/telegramqml.pro
+++ b/telegramqml.pro
@@ -1,7 +1,7 @@
 TEMPLATE = lib
 TARGET = telegramqml
 DEFINES += TELEGRAMQML_LIBRARY
-CONFIG += qt no_keywords
+CONFIG += qt no_keywords c++11
 
 uri = TelegramQml
 


### PR DESCRIPTION
With this commit:
https://github.com/Aseman-Land/TelegramQML/commit/ccd8882b1805fbd48885abe85d92eba156f1d68b#diff-cba195051f1ec0e830ff4e74d0bf4d89R1313

telegramqml can only be built with c++11 enabled.
