### PR TITLE
Do not insert again in the database unchanged users and contacts

### DIFF
--- a/telegramqml.cpp
+++ b/telegramqml.cpp
@@ -3308,12 +3308,11 @@ void TelegramQml::contactsFound_slt(qint64 id, const QList<ContactFound> &founds
 void TelegramQml::contactsGetContacts_slt(qint64 id, bool modified, const QList<Contact> &contacts, const QList<User> &users)
 {
     Q_UNUSED(id)
-    Q_UNUSED(modified)
 
     Q_FOREACH( const User & user, users )
-        insertUser(user);
+        insertUser(user, modified);
     Q_FOREACH( const Contact & contact, contacts )
-        insertContact(contact);
+        insertContact(contact, modified);
 }
 
 void TelegramQml::usersGetFullUser_slt(qint64 id, const User &user, const ContactsLink &link, const Photo &profilePhoto, const PeerNotifySettings &notifySettings, bool blocked, const QString &realFirstName, const QString &realLastName)


### PR DESCRIPTION
The function `TelegramQml::contactsGetContacts_slt` is invoked by signal
`contactsGetContactsAnswer` which is emitted by `libqtelegram-ae`.

Here the signal is emitted by `Telegram::onContactsContacts` and
`Telegram::onContactsContactsNotModified`.

The former set the second parameter to true, so this patch doesn't
change its behavior, but the latter set the modified parameter to
false, because it serves contacts and users from cache.

Since they are from caches, there is no need to call `insertUser` and
`insertContact` and add them again to the database

On my account, this removes ~250 queries to the database at startup
