### PR TITLE
[Api51 Branch] Some fixes, Qt 5.2 support

### DIFF
--- a/.directory
+++ b/.directory
@@ -1,7 +1,0 @@
-[Dolphin]
-GroupedSorting=true
-PreviewsShown=true
-SortRole=type
-Timestamp=2016,4,29,14,20,44
-Version=3
-ViewMode=1

--- a/documents/image.md
+++ b/documents/image.md
@@ -48,6 +48,7 @@
 * <font color='#074885'><b>smooth</b></font>: boolean
 * <font color='#074885'><b>sourceSize</b></font>: size
 * <font color='#074885'><b>verticalAlignment</b></font>: int
+* <font color='#074885'><b>qtQuickVersion</b></font>: string
 
 
 ### Methods

--- a/telegramimageelement.cpp
+++ b/telegramimageelement.cpp
@@ -27,6 +27,7 @@ public:
     QQuickItem *image;
     QMimeDatabase mdb;
     QSizeF imageSize;
+    QString qtQuickVersion;
 };
 
 TelegramImageElement::TelegramImageElement(QQuickItem *parent) :
@@ -34,6 +35,7 @@ TelegramImageElement::TelegramImageElement(QQuickItem *parent) :
 {
     p = new TelegramImageElementPrivate;
     p->image = 0;
+    p->qtQuickVersion = "2.5";
 
     p->handler = new TelegramDownloadHandler(this);
 
@@ -68,6 +70,20 @@ void TelegramImageElement::setEngine(TelegramEngine *engine)
 TelegramEngine *TelegramImageElement::engine() const
 {
     return p->handler->engine();
+}
+
+void TelegramImageElement::setQtQuickVersion(const QString &version)
+{
+    if(p->qtQuickVersion == version)
+        return;
+
+    p->qtQuickVersion = version;
+    Q_EMIT qtQuickVersionChanged();
+}
+
+const QString &TelegramImageElement::qtQuickVersion() const
+{
+    return p->qtQuickVersion;
 }
 
 bool TelegramImageElement::asynchronous()
@@ -287,9 +303,8 @@ void TelegramImageElement::initImage()
         return;
 
     QQmlComponent component(engine);
-    component.setData("import QtQuick 2.5\n"
-                      "Image { anchors.fill: parent; }",
-                      QUrl());
+    component.setData(QString("import QtQuick %1\n"
+                              "Image { anchors.fill: parent; }").arg(p->qtQuickVersion).toUtf8(), QUrl());
     QQuickItem *item = qobject_cast<QQuickItem *>(component.create(context));
     if(!item)
         return;

--- a/telegramimageelement.cpp
+++ b/telegramimageelement.cpp
@@ -313,7 +313,11 @@ void TelegramImageElement::initImage()
     item->setParentItem(this);
 
     connect(item, SIGNAL(asynchronousChanged()), this, SIGNAL(asynchronousChanged()));
-    connect(item, SIGNAL(autoTransformChanged()), this, SIGNAL(autoTransformChanged()));
+
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
+        connect(item, SIGNAL(autoTransformChanged()), this, SIGNAL(autoTransformChanged()));
+    #endif
+
     connect(item, SIGNAL(cacheChanged()), this, SIGNAL(cacheChanged()));
     connect(item, SIGNAL(fillModeChanged()), this, SIGNAL(fillModeChanged()));
     connect(item, SIGNAL(mirrorChanged()), this, SIGNAL(mirrorChanged()));

--- a/telegramimageelement.h
+++ b/telegramimageelement.h
@@ -16,6 +16,7 @@ class TELEGRAMQMLSHARED_EXPORT TelegramImageElement : public QQuickItem, public 
     Q_OBJECT
     Q_PROPERTY(TelegramTypeQObject* source READ source WRITE setSource NOTIFY sourceChanged)
     Q_PROPERTY(TelegramEngine* engine READ engine WRITE setEngine NOTIFY engineChanged)
+    Q_PROPERTY(QString qtQuickVersion READ qtQuickVersion WRITE setQtQuickVersion NOTIFY qtQuickVersionChanged)
     Q_PROPERTY(qint32 fileSize READ fileSize NOTIFY fileSizeChanged)
     Q_PROPERTY(qint32 downloadedSize READ downloadedSize NOTIFY downloadedSizeChanged)
     Q_PROPERTY(bool downloading READ downloading NOTIFY downloadingChanged)
@@ -50,6 +51,9 @@ public:
 
     void setEngine(TelegramEngine *engine);
     TelegramEngine *engine() const;
+
+    void setQtQuickVersion(const QString& version);
+    const QString& qtQuickVersion() const;
 
     bool asynchronous();
     void setAsynchronous(bool asynchronous);
@@ -103,6 +107,7 @@ public:
 Q_SIGNALS:
     void sourceChanged();
     void engineChanged();
+    void qtQuickVersionChanged();
     void imageSizeChanged();
     void fileSizeChanged();
     void downloadedSizeChanged();

--- a/telegrammessagelistmodel.cpp
+++ b/telegrammessagelistmodel.cpp
@@ -1357,10 +1357,10 @@ void TelegramMessageListModel::changed(QHash<QByteArray, TelegramMessageListItem
 const QHash<QByteArray, TelegramMessageListItem> *tg_mlist_model_lessthan_items = 0;
 bool tg_mlist_model_sort(const QByteArray &s1, const QByteArray &s2);
 
-QByteArrayList TelegramMessageListModel::getSortedList(const QHash<QByteArray, TelegramMessageListItem> &items)
+QList<QByteArray> TelegramMessageListModel::getSortedList(const QHash<QByteArray, TelegramMessageListItem> &items)
 {
     tg_mlist_model_lessthan_items = &items;
-    QByteArrayList list = items.keys();
+    QList<QByteArray> list = items.keys();
     qStableSort(list.begin(), list.end(), tg_mlist_model_sort);
     return list;
 }

--- a/telegrammessagelistmodel.h
+++ b/telegrammessagelistmodel.h
@@ -147,7 +147,7 @@ private:
     void fetchReplies(QList<Message> messages, int delay = 100);
     void processOnResult(const class MessagesMessages &result, QHash<QByteArray, TelegramMessageListItem> *items);
     void changed(QHash<QByteArray, TelegramMessageListItem> hash);
-    QByteArrayList getSortedList(const QHash<QByteArray, TelegramMessageListItem> &items);
+    QList<QByteArray> getSortedList(const QHash<QByteArray, TelegramMessageListItem> &items);
 
     void connectMessageSignals(const QByteArray &id, class MessageObject *message);
     void connectChatSignals(const QByteArray &id, class ChatObject *chat);

--- a/telegramqmlinitializer.cpp
+++ b/telegramqmlinitializer.cpp
@@ -23,27 +23,27 @@
 
 void TelegramQmlInitializer::init(const char *uri)
 {
-    qtelegramRegisterQmlTypes("TelegramQml", 2, 0);
+    qtelegramRegisterQmlTypes(uri, 2, 0);
     qRegisterMetaType< QList<qint32> >("QList<qint32>");
 
-    qmlRegisterUncreatableType<TelegramEnums>("TelegramQml", 2, 0, "Enums", "It's just enums");
+    qmlRegisterUncreatableType<TelegramEnums>(uri, 2, 0, "Enums", "It's just enums");
 
-    qmlRegisterType<TelegramEngine>("TelegramQml", 2, 0, "Engine");
-    qmlRegisterType<TelegramApp>("TelegramQml", 2, 0, "App");
-    qmlRegisterType<TelegramAuthenticate>("TelegramQml", 2, 0, "Authenticate");
-    qmlRegisterType<TelegramMessageFetcher>("TelegramQml", 2, 0, "MessageFetcher");
-    qmlRegisterType<TelegramDialogListModel>("TelegramQml", 2, 0, "DialogListModel");
-    qmlRegisterType<TelegramMessageSearchModel>("TelegramQml", 2, 0, "MessageSearchModel");
-    qmlRegisterType<TelegramDownloadHandler>("TelegramQml", 2, 0, "DownloadHandler");
-    qmlRegisterType<TelegramStickersCategoriesModel>("TelegramQml", 2, 0, "StickersCategoriesModel");
-    qmlRegisterType<TelegramStickersModel>("TelegramQml", 2, 0, "StickersModel");
-    qmlRegisterType<TelegramMessageListModel>("TelegramQml", 2, 0, "MessageListModel");
-    qmlRegisterType<TelegramProfileManagerModel>("TelegramQml", 2, 0, "ProfileManagerModel");
-    qmlRegisterType<TelegramPeerDetails>("TelegramQml", 2, 0, "PeerDetails");
-    qmlRegisterType<TelegramNotificationHandler>("TelegramQml", 2, 0, "NotificationHandler");
-    qmlRegisterType<TelegramHost>("TelegramQml", 2, 0, "Host");
-    qmlRegisterType<TelegramImageElement>("TelegramQml", 2, 0, "Image");
-    qmlRegisterType<TqmlDocumentExporter>("TelegramQml", 2, 0, "DocumentExporter");
+    qmlRegisterType<TelegramEngine>(uri, 2, 0, "Engine");
+    qmlRegisterType<TelegramApp>(uri, 2, 0, "App");
+    qmlRegisterType<TelegramAuthenticate>(uri, 2, 0, "Authenticate");
+    qmlRegisterType<TelegramMessageFetcher>(uri, 2, 0, "MessageFetcher");
+    qmlRegisterType<TelegramDialogListModel>(uri, 2, 0, "DialogListModel");
+    qmlRegisterType<TelegramMessageSearchModel>(uri, 2, 0, "MessageSearchModel");
+    qmlRegisterType<TelegramDownloadHandler>(uri, 2, 0, "DownloadHandler");
+    qmlRegisterType<TelegramStickersCategoriesModel>(uri, 2, 0, "StickersCategoriesModel");
+    qmlRegisterType<TelegramStickersModel>(uri, 2, 0, "StickersModel");
+    qmlRegisterType<TelegramMessageListModel>(uri, 2, 0, "MessageListModel");
+    qmlRegisterType<TelegramProfileManagerModel>(uri, 2, 0, "ProfileManagerModel");
+    qmlRegisterType<TelegramPeerDetails>(uri, 2, 0, "PeerDetails");
+    qmlRegisterType<TelegramNotificationHandler>(uri, 2, 0, "NotificationHandler");
+    qmlRegisterType<TelegramHost>(uri, 2, 0, "Host");
+    qmlRegisterType<TelegramImageElement>(uri, 2, 0, "Image");
+    qmlRegisterType<TqmlDocumentExporter>(uri, 2, 0, "DocumentExporter");
 
     initializeTypes(uri);
 }


### PR DESCRIPTION
I have made some fixes to API51 Branch, these are the main changes:
1. TelegramImageElement: QtQuick version was hardcoded in source code with version 2.5 which prevents to use it in Qt < 5.4, I have added a qtQuickVersion property in order to set it dynamically.
2. I have changed QByteArrayList type to QList&lt;QByteArray&gt; in order to make it compilable with Qt 5.2
3. TelegramImageElement's autoTransformProperty is available from Qt 5.5 so I have surrounded that statement with a #if #endif statement
4. The "import uri" can be changed dinamically (like was on TelegramQML 1.0)
