### PR TITLE
[API51] Added messageUser role in DialogListModel

### DIFF
--- a/documents/dialoglistmodel.md
+++ b/documents/dialoglistmodel.md
@@ -81,14 +81,15 @@
 |RoleMessage|265|
 |RoleMessageOut|266|
 |RoleMessageType|267|
-|RoleLastOnline|268|
-|RoleIsOnline|269|
-|RoleStatus|270|
-|RoleStatusText|271|
-|RoleTyping|272|
-|RoleUnreadCount|273|
-|RoleMute|274|
-|RoleCategory|275|
+|RoleMessageUser|268|
+|RoleLastOnline|269|
+|RoleIsOnline|270|
+|RoleStatus|271|
+|RoleStatusText|272|
+|RoleTyping|273|
+|RoleUnreadCount|274|
+|RoleMute|275|
+|RoleCategory|276|
 
 
 ### Roles
@@ -105,6 +106,7 @@
  * model.<font color='#074885'>message</font>
  * model.<font color='#074885'>messageOut</font>
  * model.<font color='#074885'>messageType</font>
+ * model.<font color='#074885'>messageUser</font>
  * model.<font color='#074885'>lastOnline</font>
  * model.<font color='#074885'>isOnline</font>
  * model.<font color='#074885'>status</font>

--- a/telegramdialoglistmodel.h
+++ b/telegramdialoglistmodel.h
@@ -63,6 +63,7 @@ public:
         RoleMessage,
         RoleMessageOut,
         RoleMessageType,
+        RoleMessageUser,
         RoleLastOnline,
         RoleIsOnline,
         RoleStatus,
@@ -127,7 +128,7 @@ private:
     void getDialogsFromServer(const class InputPeer &offset, int limit, QHash<QByteArray, TelegramDialogListItem> *items = 0);
     class InputPeer processOnResult(const class MessagesDialogs &result, QHash<QByteArray, TelegramDialogListItem> *items);
     void changed(const QHash<QByteArray, TelegramDialogListItem> &items);
-    QByteArrayList getSortedList(const QHash<QByteArray, TelegramDialogListItem> &items);
+    QList<QByteArray> getSortedList(const QHash<QByteArray, TelegramDialogListItem> &items);
 
     void connectChatSignals(const QByteArray &id, class ChatObject *chat);
     void connectUserSignals(const QByteArray &id, class UserObject *user);


### PR DESCRIPTION
This pull request adds a "messageUser" role in DialogListModel in order to retrieve the top message's sender.

I have also made made some changes here https://github.com/Dax89/TelegramQML/commit/3b176c891a2dd0a60e5e01243c9ab2b8123e18cd#diff-e5ac429fa7e7e0cb705fe0e458f8539dR606 because the "topMessageUser" variable is not always initialized when che Dialog is a group or supergroup.
I don't know if it is ok, I have tested and it works great!

I've also renamed some more QByteArrayList to QList&lt;QByteArray&gt; and updated the documentation with the new role :)
