### PR TITLE
Fix no return in nonvoid function.

### DIFF
--- a/telegramtools.cpp
+++ b/telegramtools.cpp
@@ -550,5 +550,7 @@ QString TelegramTools::userStatus(UserObject *user, std::function<QString (const
     case UserStatusObject::TypeUserStatusRecently:
         return QObject::tr("Last seen recently");
         break;
+    default:
+        return QString();
     }
 }


### PR DESCRIPTION
TelegramTools::userStatus() does not return a default value.

openSUSE build service rejects to publish the package while this warning is there.
