### PR TITLE
Bugfixes and Qt 5.2 compatibility

### DIFF
--- a/telegramabstractenginelistmodel.cpp
+++ b/telegramabstractenginelistmodel.cpp
@@ -14,7 +14,6 @@ void TelegramAbstractEngineListModel::setEngine(TelegramEngine *engine) {
         return;
     if(mEngine)
     {
-        disconnect(mEngine.data(), &TelegramEngine::telegramChanged, this, &TelegramAbstractEngineListModel::connectTelegram);
         disconnect(mEngine.data(), &TelegramEngine::telegramChanged, this, &TelegramAbstractEngineListModel::refresh);
         disconnect(mEngine.data(), &TelegramEngine::stateChanged, this, &TelegramAbstractEngineListModel::refresh);
     }
@@ -22,11 +21,11 @@ void TelegramAbstractEngineListModel::setEngine(TelegramEngine *engine) {
     mEngine = engine;
     if(mEngine)
     {
-        connect(mEngine.data(), &TelegramEngine::telegramChanged, this, &TelegramAbstractEngineListModel::connectTelegram);
         connect(mEngine.data(), &TelegramEngine::telegramChanged, this, &TelegramAbstractEngineListModel::refresh);
         connect(mEngine.data(), &TelegramEngine::stateChanged, this, &TelegramAbstractEngineListModel::refresh);
     }
 
+    connectTelegram();
     refresh();
     Q_EMIT engineChanged();
 }

--- a/telegramabstractenginelistmodel.cpp
+++ b/telegramabstractenginelistmodel.cpp
@@ -14,6 +14,7 @@ void TelegramAbstractEngineListModel::setEngine(TelegramEngine *engine) {
         return;
     if(mEngine)
     {
+        disconnect(mEngine.data(), &TelegramEngine::telegramChanged, this, &TelegramAbstractEngineListModel::connectTelegram);
         disconnect(mEngine.data(), &TelegramEngine::telegramChanged, this, &TelegramAbstractEngineListModel::refresh);
         disconnect(mEngine.data(), &TelegramEngine::stateChanged, this, &TelegramAbstractEngineListModel::refresh);
     }
@@ -21,6 +22,7 @@ void TelegramAbstractEngineListModel::setEngine(TelegramEngine *engine) {
     mEngine = engine;
     if(mEngine)
     {
+        connect(mEngine.data(), &TelegramEngine::telegramChanged, this, &TelegramAbstractEngineListModel::connectTelegram);
         connect(mEngine.data(), &TelegramEngine::telegramChanged, this, &TelegramAbstractEngineListModel::refresh);
         connect(mEngine.data(), &TelegramEngine::stateChanged, this, &TelegramAbstractEngineListModel::refresh);
     }

--- a/telegramcache.cpp
+++ b/telegramcache.cpp
@@ -540,42 +540,42 @@ void TelegramCache::refresh()
     if(!p->telegram)
         return;
 
-    connect(p->telegram, &Telegram::messagesGetHistoryAnswer, this, &TelegramCache::messagesReaded);
-    connect(p->telegram, &Telegram::messagesGetDialogsAnswer, this, &TelegramCache::dialogsReaded);
-    connect(p->telegram, &Telegram::updates, this, &TelegramCache::onUpdates);
+    connect(p->telegram.data(), &Telegram::messagesGetHistoryAnswer, this, &TelegramCache::messagesReaded);
+    connect(p->telegram.data(), &Telegram::messagesGetDialogsAnswer, this, &TelegramCache::dialogsReaded);
+    connect(p->telegram.data(), &Telegram::updates, this, &TelegramCache::onUpdates);
 
-    connect(p->telegram, &Telegram::channelsCreateChannelAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::channelsEditAdminAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::channelsEditTitleAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::channelsEditPhotoAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::channelsJoinChannelAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::channelsLeaveChannelAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::channelsInviteToChannelAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::channelsKickFromChannelAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::channelsDeleteChannelAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::channelsToggleInvitesAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::channelsToggleSignaturesAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::channelsUpdatePinnedMessageAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsCreateChannelAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsEditAdminAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsEditTitleAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsEditPhotoAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsJoinChannelAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsLeaveChannelAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsInviteToChannelAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsKickFromChannelAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsDeleteChannelAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsToggleInvitesAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsToggleSignaturesAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::channelsUpdatePinnedMessageAnswer, this, &TelegramCache::updates);
 
-    connect(p->telegram, &Telegram::messagesSendMessageAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesSendMediaAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesForwardMessagesAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesEditChatTitleAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesEditChatPhotoAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesAddChatUserAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesDeleteChatUserAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesCreateChatAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesForwardMessageAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesSendBroadcastAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesImportChatInviteAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesStartBotAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesToggleChatAdminsAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesMigrateChatAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesSendInlineBotResultAnswer, this, &TelegramCache::updates);
-    connect(p->telegram, &Telegram::messagesEditMessageAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesSendMessageAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesSendMediaAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesForwardMessagesAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesEditChatTitleAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesEditChatPhotoAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesAddChatUserAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesDeleteChatUserAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesCreateChatAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesForwardMessageAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesSendBroadcastAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesImportChatInviteAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesStartBotAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesToggleChatAdminsAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesMigrateChatAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesSendInlineBotResultAnswer, this, &TelegramCache::updates);
+    connect(p->telegram.data(), &Telegram::messagesEditMessageAnswer, this, &TelegramCache::updates);
 
     const qint32 currentPts = pts();
-    connect(p->telegram, &Telegram::authLoggedIn, this, [this, currentPts](){
+    connect(p->telegram.data(), &Telegram::authLoggedIn, this, [this, currentPts](){
         loadFromPts(currentPts);
     });
 }

--- a/telegramimageelement.cpp
+++ b/telegramimageelement.cpp
@@ -337,7 +337,7 @@ void TelegramImageElement::setImage(const QString &image)
     else
         p->imageSize = QSizeF();
 
-    p->image->setProperty("source", QUrl::fromLocalFile(image));
+    p->image->setProperty("source", (image.isEmpty() ? QUrl() : QUrl::fromLocalFile(image)));
     Q_EMIT imageSizeChanged();
     Q_EMIT currentImageChanged();
 }

--- a/telegramqmlinitializer.cpp
+++ b/telegramqmlinitializer.cpp
@@ -54,42 +54,42 @@ void TelegramQmlInitializer::init(const char *uri, bool exportMode)
     qtelegramRegisterQmlTypes(uri, 2, 0);
     qRegisterMetaType< QList<qint32> >("QList<qint32>");
 
-    registerType<TelegramEngine>("TelegramQml", 2, 0, "Engine", exportMode);
-    registerType<TelegramApp>("TelegramQml", 2, 0, "App", exportMode);
-    registerType<TelegramHost>("TelegramQml", 2, 0, "Host", exportMode);
-    registerType<TelegramCache>("TelegramQml", 2, 0, "Cache", exportMode);
-    registerType<TelegramAuthStore>("TelegramQml", 2, 0, "AuthStore", exportMode);
-    registerType<TelegramAuthenticate>("TelegramQml", 2, 0, "Authenticate", exportMode);
+    registerType<TelegramEngine>(uri, 2, 0, "Engine", exportMode);
+    registerType<TelegramApp>(uri, 2, 0, "App", exportMode);
+    registerType<TelegramHost>(uri, 2, 0, "Host", exportMode);
+    registerType<TelegramCache>(uri, 2, 0, "Cache", exportMode);
+    registerType<TelegramAuthStore>(uri, 2, 0, "AuthStore", exportMode);
+    registerType<TelegramAuthenticate>(uri, 2, 0, "Authenticate", exportMode);
 
-    registerModel<TelegramDialogListModel>("TelegramQml", 2, 0, "DialogListModel", exportMode);
-    registerModel<TelegramMessageListModel>("TelegramQml", 2, 0, "MessageListModel", exportMode);
-    registerModel<TelegramMessageSearchModel>("TelegramQml", 2, 0, "MessageSearchModel", exportMode);
-    registerModel<TelegramMediaListModel>("TelegramQml", 2, 0, "MediaListModel", exportMode);
-    registerModel<TelegramTopMessagesModel>("TelegramQml", 2, 0, "TopMessagesModel", exportMode);
-    registerModel<TelegramStickersCategoriesModel>("TelegramQml", 2, 0, "StickersCategoriesModel", exportMode);
-    registerModel<TelegramStickersModel>("TelegramQml", 2, 0, "StickersModel", exportMode);
-    registerModel<TelegramMembersListModel>("TelegramQml", 2, 0, "MembersListModel", exportMode);
-    registerModel<TelegramProfileManagerModel>("TelegramQml", 2, 0, "ProfileManagerModel", exportMode);
+    registerModel<TelegramDialogListModel>(uri, 2, 0, "DialogListModel", exportMode);
+    registerModel<TelegramMessageListModel>(uri, 2, 0, "MessageListModel", exportMode);
+    registerModel<TelegramMessageSearchModel>(uri, 2, 0, "MessageSearchModel", exportMode);
+    registerModel<TelegramMediaListModel>(uri, 2, 0, "MediaListModel", exportMode);
+    registerModel<TelegramTopMessagesModel>(uri, 2, 0, "TopMessagesModel", exportMode);
+    registerModel<TelegramStickersCategoriesModel>(uri, 2, 0, "StickersCategoriesModel", exportMode);
+    registerModel<TelegramStickersModel>(uri, 2, 0, "StickersModel", exportMode);
+    registerModel<TelegramMembersListModel>(uri, 2, 0, "MembersListModel", exportMode);
+    registerModel<TelegramProfileManagerModel>(uri, 2, 0, "ProfileManagerModel", exportMode);
 
-    registerType<TelegramImageElement>("TelegramQml", 2, 0, "Image", exportMode);
-    registerType<TelegramDownloadHandler>("TelegramQml", 2, 0, "DownloadHandler", exportMode);
+    registerType<TelegramImageElement>(uri, 2, 0, "Image", exportMode);
+    registerType<TelegramDownloadHandler>(uri, 2, 0, "DownloadHandler", exportMode);
 
-    registerType<TelegramMessageFetcher>("TelegramQml", 2, 0, "MessageFetcher", exportMode);
-    registerType<TelegramPeerDetails>("TelegramQml", 2, 0, "PeerDetails", exportMode);
-    registerType<TelegramNotificationHandler>("TelegramQml", 2, 0, "NotificationHandler", exportMode);
-    registerType<TelegramStatus>("TelegramQml", 2, 0, "Status", exportMode);
-    registerType<TelegramStatusTyping>("TelegramQml", 2, 0, "StatusTyping", exportMode);
+    registerType<TelegramMessageFetcher>(uri, 2, 0, "MessageFetcher", exportMode);
+    registerType<TelegramPeerDetails>(uri, 2, 0, "PeerDetails", exportMode);
+    registerType<TelegramNotificationHandler>(uri, 2, 0, "NotificationHandler", exportMode);
+    registerType<TelegramStatus>(uri, 2, 0, "Status", exportMode);
+    registerType<TelegramStatusTyping>(uri, 2, 0, "StatusTyping", exportMode);
     if(exportMode)
     {
-        registerType<MessagesFilterObj>("TelegramQml", 2, 0, "MessagesFilter", exportMode);
-        registerType<SendMessageActionObj>("TelegramQml", 2, 0, "SendMessageAction", exportMode);
+        registerType<MessagesFilterObj>(uri, 2, 0, "MessagesFilter", exportMode);
+        registerType<SendMessageActionObj>(uri, 2, 0, "SendMessageAction", exportMode);
 
-        registerType<TqObject>("TelegramQml", 2, 0, "TqObject", exportMode);
-        exportItem<TelegramAbstractListModel>("TelegramQml", 2, 0, "AbstractListModel");
-        exportItem<TelegramAbstractEngineListModel>("TelegramQml", 2, 0, "AbstractEngineListModel");
+        registerType<TqObject>(uri, 2, 0, "TqObject", exportMode);
+        exportItem<TelegramAbstractListModel>(uri, 2, 0, "AbstractListModel");
+        exportItem<TelegramAbstractEngineListModel>(uri, 2, 0, "AbstractEngineListModel");
     }
 
-    registerType<TelegramQmlSharedPointer>("TelegramQml", 2, 0, "SharedPointer", exportMode);
+    registerType<TelegramQmlSharedPointer>(uri, 2, 0, "SharedPointer", exportMode);
     registerUncreatableType<TelegramEnums>(uri, 2, 0, "Enums", "It's just enums", exportMode);
 
     qmlRegisterType<TqmlDocumentExporter>(uri, 2, 0, "DocumentExporter");


### PR DESCRIPTION
This pull request contains:
- Partial Qt 5.2 compatibility by adding data() method in TelegramCache when connecting signals
- Suppressed warning in TelegramImageElement when image's url is empty
- Restored used defined import uri feature from TelegramQml 1.0

And a **very important** fix:
I have modified TelegramAbstractEngineModel so connectTelegram() is always called when a TelegramEngine instance is set.

This fixes TelegramQml's model update issues by connecting signals immmediately, instead of waiting for telegramChanged() signal.

With this fix I'm able to receive chat updates correctly because onUpdate() slot is connected and called correctly.
